### PR TITLE
feat(ops): complete Discord IaC bundle (ready-to-deploy)

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -87,6 +87,9 @@ jobs:
             bash -n "$f"
           done
 
+      - name: Install PyYAML (for dotbot manifest parse)
+        run: python3 -m pip install --user --break-system-packages "pyyaml==6.0.2" || python3 -m pip install --user "pyyaml==6.0.2"
+
       - name: dotbot dry-run (structure only, no symlinks)
         run: |
           set -euo pipefail

--- a/configs/claude/hooks/issue-link-check.sh
+++ b/configs/claude/hooks/issue-link-check.sh
@@ -5,6 +5,8 @@
 
 set -u  # kein -e: Warn-Hook darf nie harte Fehler werfen
 
+# stdin muss drained werden (Claude-Code Hook-Contract), Inhalt nicht benötigt
+# shellcheck disable=SC2034  # INPUT wird künftig für tool-specific branch-checks ausgewertet
 INPUT="$(cat)"
 
 # Außerhalb eines Git-Repos → nichts zu tun

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,7 @@ if [[ -f "${HOME}/.openclaw/.env" ]]; then
     set +a
     _ok "sourced ~/.openclaw/.env"
 else
+    # shellcheck disable=SC2088  # tilde ist hier nur display-text, nicht path-expansion
     _warn "~/.openclaw/.env not found — MCP registration may fail for some servers"
 fi
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -11,6 +11,7 @@ der Messaging-Bus für die AI-Review-Pipeline.
 ops/
 ├── discord-bot/
 │   ├── provision_channels.py   Discord Channel Provisioning (Python, idempotent)
+│   ├── init-server.sh          Wrapper: provisioniert Default-Projekt-Liste in einem Aufruf
 │   ├── register-bot.md         Schritt-für-Schritt Discord Dev Portal Setup
 │   ├── setup.sh                One-Shot Orchestrations-Script (alles auf einmal)
 │   └── .env.example            Alle benötigten Env-Vars (ohne Werte)

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,175 @@
+# ops — Discord Bot + ops-n8n + Tailscale Funnel
+
+Dieser Ordner enthält die vollständige Infrastructure-as-Code für den **Nathan Ops Discord Bot**:
+der Messaging-Bus für die AI-Review-Pipeline.
+
+---
+
+## Übersicht
+
+```
+ops/
+├── discord-bot/
+│   ├── provision_channels.py   Discord Channel Provisioning (Python, idempotent)
+│   ├── register-bot.md         Schritt-für-Schritt Discord Dev Portal Setup
+│   ├── setup.sh                One-Shot Orchestrations-Script (alles auf einmal)
+│   └── .env.example            Alle benötigten Env-Vars (ohne Werte)
+└── n8n/
+    ├── docker-compose.yml      ops-n8n Container (Port 5679, Volume ops-n8n-data)
+    ├── workflows/
+    │   ├── ai-review-dispatcher.json   Webhook → Discord Components v2 + Inline-Buttons
+    │   ├── ai-review-callback.json     Discord Interaction → Ed25519 Verify → GitHub API
+    │   └── ai-review-escalation.json  Eskalation → Discord Alerts Channel
+    └── scripts/
+        ├── setup-ops-n8n.sh    Container starten + Workflows importieren
+        └── backup-ops-n8n.sh   Wöchentliches Backup (cron-kompatibel)
+```
+
+**Trennung von ai-portal-n8n:**
+- `ai-portal-n8n` (Port 5678): Business-Workflows (Finance, Research, Email). Bleibt unverändert.
+- `ops-n8n` (Port 5679): Ausschließlich AI-Review Messaging-Bridge. Teil von `agent-stack`.
+
+---
+
+## Setup-Sequenz (10 Schritte)
+
+### Manuelle Schritte (einmalig von Nico)
+
+- [ ] **1.** Discord Developer Portal — Application "Nathan Ops Bot" anlegen
+      → Anleitung: [discord-bot/register-bot.md](discord-bot/register-bot.md)
+
+- [ ] **2.** Bot-Token kopieren → `DISCORD_BOT_TOKEN` in `~/.openclaw/.env`
+
+- [ ] **3.** Application ID + Public Key kopieren → `DISCORD_APPLICATION_ID` + `DISCORD_PUBLIC_KEY` in `~/.openclaw/.env`
+
+- [ ] **4.** OAuth2 URL generieren, Bot zum "Nathan Ops" Guild einladen
+
+- [ ] **5.** Guild ID kopieren (Discord Dev Mode) → `DISCORD_GUILD_ID` in `~/.openclaw/.env`
+
+### Automatisierte Schritte (via `setup.sh`)
+
+- [ ] **6.** `setup.sh` ausführen:
+  ```bash
+  bash ops/discord-bot/setup.sh
+  ```
+  Dieser Schritt erledigt:
+  - Channel-Provisioning für alle 5 Projekte (idempotent)
+  - ops-n8n Container starten
+  - Workflows importieren und aktivieren
+  - Tailscale Funnel konfigurieren
+
+- [ ] **7.** In n8n UI: API Key generieren (`Einstellungen → API → API Key erstellen`)
+      → `N8N_API_KEY` in `~/.openclaw/.env` setzen, dann erneut ausführen:
+  ```bash
+  bash ops/n8n/scripts/setup-ops-n8n.sh --import-only
+  ```
+
+### Abschluss (einmalig manuell)
+
+- [ ] **8.** Discord Dev Portal → General Information → "Interactions Endpoint URL":
+  ```
+  https://r2d2.tail4fc6dd.ts.net/webhook/discord-interaction
+  ```
+  "Save Changes" → Discord verifiziert Endpoint automatisch.
+
+- [ ] **9.** Pro Projekt `DISCORD_CHANNEL_ID` in `.ai-review/config.yaml` eintragen
+      (Channel-ID via Discord Dev Mode: Rechtsklick auf Channel → "Copy Channel ID")
+
+- [ ] **10.** Smoke-Test: Test-PR erstellen → Pipeline sollte Discord-Nachricht senden
+
+---
+
+## Komponenten-Details
+
+### discord-bot/provision_channels.py
+
+Erstellt pro Projekt:
+- `#ai-review-<project>` (Haupt-Review-Channel)
+- `#ai-review-shadow-<project>` (Shadow-Mode-Channel, Phase 4)
+
+Sowie einmalig:
+- `#ai-review-alerts-global` (cross-projekt Eskalationen)
+
+Alle in Category "AI Review".
+
+```bash
+# Dry-Run (keine API-Calls)
+python provision_channels.py --guild-id $DISCORD_GUILD_ID --projects ai-portal --dry-run
+
+# Live
+python provision_channels.py --guild-id $DISCORD_GUILD_ID \
+  --projects ai-portal,nathan-cockpit,openclaw-office,research-workflow-n8n,ai-review-pipeline
+```
+
+Tests: `tests/test_provision_channels.py` (12 Tests, TDD).
+
+### n8n Workflows
+
+| Workflow | Webhook-Pfad | Zweck |
+|---|---|---|
+| `ai-review-dispatcher.json` | `POST /webhook/ai-review-dispatch` | Empfängt Pipeline-Payload, rendert Discord Components v2 mit Buttons |
+| `ai-review-callback.json` | `POST /webhook/discord-interaction` | Empfängt Button-Clicks, Ed25519-Verify, GitHub API Call |
+| `ai-review-escalation.json` | `POST /webhook/ai-review-escalation` | Alert-Nachricht mit @here in Alerts-Channel |
+
+**Discord Components v2 Buttons (in dispatcher):**
+
+```
+[Approve]   [Auto-Fix]   [Manual]
+  PRIMARY   SECONDARY     DANGER
+  custom_id: approve:{pr} | fix:{pr} | manual:{pr}
+```
+
+**Ed25519 Verify (in callback):**
+- Pflicht für Discord Interactions (Plan §670)
+- `DISCORD_PUBLIC_KEY` aus env
+- Bei fehlgeschlagener Verify: HTTP 401
+- Bei Discord PING (type:1): sofort `{type:1}` zurück
+
+### ops-n8n docker-compose
+
+- Image: `n8nio/n8n:latest` (kein Custom-Build)
+- Port: `5679:5678` (host:container)
+- Volume: `ops-n8n-data`
+- Env: `~/.openclaw/.env`
+- Execution Timeout: 600s
+
+### Tailscale Funnel
+
+Discord braucht einen öffentlichen HTTPS-Endpoint für Interactions (Button-Clicks).
+Tailscale Funnel exposed `localhost:5679/webhook/discord-interaction` via:
+
+```
+https://r2d2.tail4fc6dd.ts.net/webhook/discord-interaction
+```
+
+```bash
+# Starten (in setup.sh automatisiert)
+sudo tailscale funnel --bg --set-path /webhook/discord-interaction localhost:5679
+
+# Status prüfen
+sudo tailscale funnel status
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Diagnose | Lösung |
+|---|---|---|
+| Bot nicht im Guild | `curl ... /guilds/$DISCORD_GUILD_ID` → 401/403 | OAuth2 URL neu generieren, Bot erneut einladen |
+| `provision_channels.py` → 403 | Bot fehlt "Manage Channels" Permission | Bot-Permissions im Dev Portal ergänzen, neu einladen |
+| n8n nicht erreichbar | `curl http://127.0.0.1:5679/healthz` | `docker compose -f ops/n8n/docker-compose.yml up -d` |
+| Workflow-Import schlägt fehl | `docker logs ops-n8n` | N8N_API_KEY prüfen, n8n UI öffnen |
+| Discord Endpoint Verify fehlschlägt | Tailscale Funnel Status + Workflow aktiv? | `sudo tailscale funnel status`, Workflow in n8n aktivieren |
+| Ed25519 Verify schlägt fehl | `DISCORD_PUBLIC_KEY` falsch? | Aus Dev Portal General Information neu kopieren |
+| Button-Click ohne GitHub-Aktion | GitHub Token Scopes? | `GITHUB_TOKEN` braucht `repo` + `workflow` Scopes |
+
+---
+
+## Referenzen
+
+- [register-bot.md](discord-bot/register-bot.md) — Discord Dev Portal Setup
+- [Plan §269-399](../.claude/plans/) — n8n-Topologie + Discord-Architektur
+- [Plan §748-760](../.claude/plans/) — R1 Tailscale Funnel Entscheidung
+- [Discord API Docs](https://discord.com/developers/docs/interactions/message-components) — Components v2
+- [ai-review-pipeline](https://github.com/EtroxTaran/ai-review-pipeline) — Pipeline-Code + discord_notify.py

--- a/ops/discord-bot/.env.example
+++ b/ops/discord-bot/.env.example
@@ -1,0 +1,42 @@
+# Discord Bot Environment Variables
+# Diese Datei listet alle benötigten Env-Vars. Keine echten Werte hier committen.
+# Werte gehören ausschließlich in ~/.openclaw/.env
+#
+# Kopier-Befehl:
+#   cp ops/discord-bot/.env.example ~/.openclaw/.env
+#   # dann Werte eintragen
+
+# ---------------------------------------------------------------------------
+# Discord Application Credentials
+# ---------------------------------------------------------------------------
+
+# Bot-Token aus Discord Dev Portal → Bot Tab → "Reset Token"
+# Format: <application_id>.<random>.<signature>
+DISCORD_BOT_TOKEN=
+
+# Application ID (aus Discord Dev Portal → General Information → Application ID)
+DISCORD_APPLICATION_ID=
+
+# Guild (Server) ID — aus Discord Dev Mode: rechtsklick auf Server → Copy Server ID
+DISCORD_GUILD_ID=
+
+# Public Key (aus Discord Dev Portal → General Information → Public Key)
+# Wird für Ed25519 Signature Verification der Interactions benötigt
+DISCORD_PUBLIC_KEY=
+
+# ---------------------------------------------------------------------------
+# n8n Operations
+# ---------------------------------------------------------------------------
+
+# API Key für ops-n8n REST API (generiert in n8n UI → Settings → API → Create API Key)
+N8N_API_KEY=
+
+# ---------------------------------------------------------------------------
+# GitHub Integration
+# ---------------------------------------------------------------------------
+
+# GitHub PAT mit Scopes: repo, workflow (für PR-Comments + Workflow-Dispatch)
+GITHUB_TOKEN=
+
+# Repository im Format "owner/repo" für GitHub API Calls aus n8n
+GITHUB_REPO=

--- a/ops/discord-bot/init-server.sh
+++ b/ops/discord-bot/init-server.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# init-server.sh — Initial Discord-Server-Setup für Nathan-Ops Guild.
+#
+# Erstellt (idempotent):
+#   - Category "AI Review"
+#   - Pro Projekt: #ai-review-<project> + #ai-review-shadow-<project>
+#   - #ai-review-alerts-global (cross-projekt Escalations)
+#
+# Projekt-Liste ist die Nathan-Ops Default-Liste. Für weitere Projekte:
+# Entweder DISCORD_PROJECTS env-var überschreiben, oder provision_channels.py
+# direkt mit eigenen --projects aufrufen.
+#
+# Required env:
+#   DISCORD_BOT_TOKEN  — Bot-Token aus Discord Dev Portal (in ~/.openclaw/.env)
+#   DISCORD_GUILD_ID   — Server-ID aus Discord Dev-Mode (in ~/.openclaw/.env)
+#
+# Optional:
+#   DISCORD_PROJECTS   — CSV-Liste (Default: siehe PROJECTS_DEFAULT unten)
+#   DRY_RUN            — "1" für Preview ohne API-Writes
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PROVISION_PY="${SCRIPT_DIR}/provision_channels.py"
+readonly ENV_FILE="${HOME}/.openclaw/.env"
+
+readonly PROJECTS_DEFAULT="ai-portal,ai-review-pipeline,agent-stack,nathan-cockpit,openclaw-office,research-workflow-n8n"
+
+die() { printf 'init-server: %s\n' "$*" >&2; exit 1; }
+
+# --- Env laden ------------------------------------------------------------
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+# --- Preflight ------------------------------------------------------------
+command -v python3 >/dev/null 2>&1 || die "python3 nicht gefunden"
+[[ -f "$PROVISION_PY" ]] || die "provision_channels.py fehlt: $PROVISION_PY"
+python3 -c "import requests" 2>/dev/null || die "python requests fehlt — 'pip install --user requests' oder venv aktivieren"
+
+: "${DISCORD_BOT_TOKEN:?DISCORD_BOT_TOKEN nicht gesetzt — siehe ops/discord-bot/register-bot.md}"
+: "${DISCORD_GUILD_ID:?DISCORD_GUILD_ID nicht gesetzt — siehe ops/discord-bot/register-bot.md}"
+
+readonly PROJECTS="${DISCORD_PROJECTS:-$PROJECTS_DEFAULT}"
+
+# --- Provisioning ---------------------------------------------------------
+echo ">>> Initial Discord-Setup startet"
+echo "    Guild:    ${DISCORD_GUILD_ID}"
+echo "    Projekte: ${PROJECTS}"
+echo "    Modus:    $([[ "${DRY_RUN:-0}" == "1" ]] && echo 'DRY-RUN' || echo 'LIVE')"
+echo ""
+
+extra_args=()
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    extra_args+=("--dry-run")
+fi
+
+# Kategorie-Name ist „AI Review" per default, via Env überschreibbar
+if [[ -n "${DISCORD_CATEGORY_NAME:-}" ]]; then
+    extra_args+=("--category" "$DISCORD_CATEGORY_NAME")
+fi
+
+DISCORD_BOT_TOKEN="$DISCORD_BOT_TOKEN" \
+python3 "$PROVISION_PY" \
+    --guild-id "$DISCORD_GUILD_ID" \
+    --projects "$PROJECTS" \
+    "${extra_args[@]}"
+
+echo ""
+echo ">>> Fertig. Channel-IDs via Discord Dev-Mode → Rechtsklick → 'ID kopieren'."
+echo "    Pro Projekt die ID in <projekt>/.ai-review/config.yaml → notifications.discord.channel_id eintragen."

--- a/ops/discord-bot/provision_channels.py
+++ b/ops/discord-bot/provision_channels.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+provision_channels.py — Discord Guild Channel Provisioning für AI-Review.
+
+Erstellt pro Projekt die Channels:
+  #ai-review-<project>
+  #ai-review-shadow-<project>
+
+sowie einmalig:
+  #ai-review-alerts-global  (cross-projekt Eskalationen)
+
+Alle Channels landen in einer gemeinsamen Category "AI Review".
+
+Idempotent: re-run erkennt existierende Channels per Name, kein Duplikat.
+Fail-Open: schlägt ein Channel-Create fehl → Log + weiter, kein früher Exit.
+
+Usage:
+    python provision_channels.py --guild-id <id> --projects ai-portal,nathan-cockpit
+    python provision_channels.py --guild-id <id> --projects ai-portal --dry-run
+    python provision_channels.py --guild-id <id> --projects ai-portal --category "AI Review"
+
+Environment:
+    DISCORD_BOT_TOKEN  (required)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Konfiguration
+# ---------------------------------------------------------------------------
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+CATEGORY_NAME = "AI Review"
+ALERTS_CHANNEL_NAME = "ai-review-alerts-global"
+
+# Discord Channel Types
+CHANNEL_TYPE_TEXT = 0
+CHANNEL_TYPE_CATEGORY = 4
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+def channel_name_for_project(project: str) -> tuple[str, str]:
+    """
+    Leitet Review- und Shadow-Channel-Namen aus Projektnamen ab.
+
+    Returns:
+        (review_channel_name, shadow_channel_name)
+    """
+    review_name = f"ai-review-{project}"
+    shadow_name = f"ai-review-shadow-{project}"
+    return review_name, shadow_name
+
+
+# ---------------------------------------------------------------------------
+# Discord Client
+# ---------------------------------------------------------------------------
+
+class DiscordClient:
+    """Minimaler Discord REST API v10 Client (nur was für Channel-Provisioning nötig)."""
+
+    def __init__(self, token: Optional[str] = None) -> None:
+        if token is None:
+            token = os.environ.get("DISCORD_BOT_TOKEN")
+            if not token:
+                raise EnvironmentError(
+                    "DISCORD_BOT_TOKEN nicht gesetzt. "
+                    "Bitte in ~/.openclaw/.env oder als env-var exportieren."
+                )
+        self.token = token
+        self._headers = {
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        }
+
+    def list_guild_channels(self, guild_id: str) -> list[dict]:
+        """Gibt alle Channels (inkl. Categories) des Guilds zurück."""
+        url = f"{DISCORD_API_BASE}/guilds/{guild_id}/channels"
+        response = requests.get(url, headers=self._headers, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+    def create_channel(
+        self,
+        guild_id: str,
+        name: str,
+        channel_type: int = CHANNEL_TYPE_TEXT,
+        parent_id: Optional[str] = None,
+    ) -> dict:
+        """Erstellt einen Channel im Guild. Gibt die erstellten Channel-Daten zurück."""
+        url = f"{DISCORD_API_BASE}/guilds/{guild_id}/channels"
+        payload: dict = {
+            "name": name,
+            "type": channel_type,
+        }
+        if parent_id:
+            payload["parent_id"] = parent_id
+        response = requests.post(url, headers=self._headers, json=payload, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Core Provisioning Logic
+# ---------------------------------------------------------------------------
+
+def provision_guild(
+    client: DiscordClient,
+    guild_id: str,
+    projects: list[str],
+    dry_run: bool = False,
+    category_name: str = CATEGORY_NAME,
+) -> dict:
+    """
+    Legt alle benötigten Channels im Discord-Guild an.
+
+    Idempotent: existierende Channels werden übersprungen.
+    Fail-Open: Exception bei einem Channel → Log + weiter.
+
+    Returns:
+        Wenn dry_run=False: {"created": int, "skipped": int, "failed": int}
+        Wenn dry_run=True:  {"would_create": int, "skipped": int}
+    """
+    # --- Bestandsaufnahme ---
+    logger.info("Lade existierende Channels für Guild %s ...", guild_id)
+    existing = client.list_guild_channels(guild_id)
+    existing_names: set[str] = {ch["name"] for ch in existing}
+    existing_categories: dict[str, str] = {
+        ch["name"]: ch["id"] for ch in existing if ch["type"] == CHANNEL_TYPE_CATEGORY
+    }
+
+    created = 0
+    skipped = 0
+    failed = 0
+    would_create = 0
+
+    # --- Gewünschte Channels berechnen ---
+    # 1. Category
+    # 2. Pro Projekt: review + shadow
+    # 3. Alerts-Global
+    desired: list[dict] = []
+
+    # Category zuerst (kein parent_id, type=4)
+    desired.append({
+        "name": category_name,
+        "type": CHANNEL_TYPE_CATEGORY,
+        "parent_id": None,
+        "is_category": True,
+    })
+
+    for project in projects:
+        review_name, shadow_name = channel_name_for_project(project)
+        desired.append({"name": review_name, "type": CHANNEL_TYPE_TEXT, "parent_id": None})
+        desired.append({"name": shadow_name, "type": CHANNEL_TYPE_TEXT, "parent_id": None})
+
+    desired.append({
+        "name": ALERTS_CHANNEL_NAME,
+        "type": CHANNEL_TYPE_TEXT,
+        "parent_id": None,
+    })
+
+    # --- Category-ID bestimmen / anlegen ---
+    # Wird nach Category-Create bekannt; Text-Channels werden darunter gehängt.
+    category_id: Optional[str] = existing_categories.get(category_name)
+
+    for item in desired:
+        name = item["name"]
+        ch_type = item["type"]
+        is_category = item.get("is_category", False)
+
+        if name in existing_names:
+            logger.info("  SKIP  %s (existiert bereits)", name)
+            skipped += 1
+            continue
+
+        if dry_run:
+            logger.info("  DRY   %s (würde erstellt werden)", name)
+            would_create += 1
+            continue
+
+        # Für Text-Channels: parent_id = category_id (falls vorhanden)
+        parent_id = None if is_category else category_id
+
+        try:
+            result = client.create_channel(
+                guild_id=guild_id,
+                name=name,
+                channel_type=ch_type,
+                parent_id=parent_id,
+            )
+            logger.info("  OK    %s (id=%s)", name, result.get("id", "?"))
+            created += 1
+
+            # Category-ID für nachfolgende Channels merken
+            if is_category:
+                category_id = result.get("id")
+
+        except Exception as exc:
+            logger.error("  FAIL  %s — %s", name, exc)
+            failed += 1
+            # Fail-Open: weitermachen mit nächstem Channel
+
+    if dry_run:
+        return {"would_create": would_create, "skipped": skipped}
+
+    return {"created": created, "skipped": skipped, "failed": failed}
+
+
+# ---------------------------------------------------------------------------
+# CLI Entry Point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Discord Guild Channel Provisioning für AI-Review",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Beispiele:
+  python provision_channels.py --guild-id 1234567890 --projects ai-portal,nathan-cockpit
+  python provision_channels.py --guild-id 1234567890 --projects ai-portal --dry-run
+  python provision_channels.py --guild-id 1234567890 --projects ai-portal --category "AI Review"
+""",
+    )
+    parser.add_argument(
+        "--guild-id",
+        required=True,
+        help="Discord Guild (Server) ID",
+    )
+    parser.add_argument(
+        "--projects",
+        required=True,
+        help="Komma-getrennte Projekt-Namen, z.B. ai-portal,nathan-cockpit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Keine API-Calls, nur zeigen was gemacht werden würde",
+    )
+    parser.add_argument(
+        "--category",
+        default=CATEGORY_NAME,
+        help=f'Name der Discord-Category (default: "{CATEGORY_NAME}")',
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Debug-Logging aktivieren",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.dry_run:
+        logger.info("=== DRY-RUN MODE — keine API-Calls ===")
+
+    projects = [p.strip() for p in args.projects.split(",") if p.strip()]
+    if not projects:
+        logger.error("Keine Projekte angegeben.")
+        return 1
+
+    try:
+        client = DiscordClient()
+    except EnvironmentError as exc:
+        logger.error("%s", exc)
+        return 1
+
+    result = provision_guild(
+        client=client,
+        guild_id=args.guild_id,
+        projects=projects,
+        dry_run=args.dry_run,
+        category_name=args.category,
+    )
+
+    if args.dry_run:
+        logger.info(
+            "Fertig (dry-run): %d würden erstellt, %d übersprungen.",
+            result.get("would_create", 0),
+            result.get("skipped", 0),
+        )
+    else:
+        logger.info(
+            "Fertig: %d erstellt, %d übersprungen, %d fehlgeschlagen.",
+            result.get("created", 0),
+            result.get("skipped", 0),
+            result.get("failed", 0),
+        )
+        if result.get("failed", 0) > 0:
+            logger.warning(
+                "%d Channel(s) konnten nicht erstellt werden. "
+                "Bitte Logs prüfen und ggf. manuell anlegen.",
+                result["failed"],
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/discord-bot/register-bot.md
+++ b/ops/discord-bot/register-bot.md
@@ -1,0 +1,160 @@
+# register-bot — Discord Application Setup Runbook
+
+Schritt-für-Schritt Anleitung zum Einrichten des "Nathan Ops Bot" im Discord Developer Portal.
+Am Ende dieses Runbooks:
+- Bot ist im "Nathan Ops" Guild als Mitglied
+- `DISCORD_BOT_TOKEN` + `DISCORD_GUILD_ID` + `DISCORD_APPLICATION_ID` + `DISCORD_PUBLIC_KEY` stehen in `~/.openclaw/.env`
+- `setup.sh` kann ausgeführt werden
+
+---
+
+## Voraussetzungen
+
+- Zugang zu [Discord Developer Portal](https://discord.com/developers/applications) (Nicos Account)
+- Discord Desktop oder Web Client mit **Developer Mode** eingeschaltet
+- r2d2 erreichbar via SSH oder Tailscale
+
+---
+
+## Schritt 1 — Application anlegen
+
+1. Öffne [discord.com/developers/applications](https://discord.com/developers/applications)
+2. Klick "New Application"
+3. Name: **Nathan Ops Bot**
+4. "Create" bestätigen
+5. Auf der "General Information"-Seite:
+   - **Application ID** kopieren → `DISCORD_APPLICATION_ID` in `~/.openclaw/.env`
+   - **Public Key** kopieren → `DISCORD_PUBLIC_KEY` in `~/.openclaw/.env`
+
+```bash
+# ~/.openclaw/.env ergänzen:
+DISCORD_APPLICATION_ID=<Application ID aus General Information>
+DISCORD_PUBLIC_KEY=<Public Key aus General Information>
+```
+
+---
+
+## Schritt 2 — Bot erstellen und Token kopieren
+
+1. Im linken Menü: **Bot** auswählen
+2. Klick "Add Bot" → "Yes, do it!"
+3. Unter "TOKEN": "Reset Token" klicken → Token bestätigen
+4. **Token sofort kopieren** (wird nur einmal angezeigt) → `DISCORD_BOT_TOKEN` in `~/.openclaw/.env`
+
+```bash
+# ~/.openclaw/.env ergänzen:
+DISCORD_BOT_TOKEN=<Bot Token>
+```
+
+> Sicherheitshinweis: Token niemals committen. `.env`-Datei ist in `.gitignore`.
+
+### Bot-Optionen (Pflicht)
+
+Im Bot-Tab folgende Schalter aktivieren:
+- **Message Content Intent** → ON (für Message-Parsing falls nötig)
+- **Server Members Intent** → OFF (nicht benötigt)
+- **Presence Intent** → OFF (nicht benötigt)
+
+---
+
+## Schritt 3 — OAuth2 URL generieren und Bot einladen
+
+1. Im linken Menü: **OAuth2** → **URL Generator**
+2. **Scopes** auswählen:
+   - `bot`
+   - `applications.commands`
+3. **Bot Permissions** auswählen (Minimal-Prinzip):
+
+   | Permission | Zweck |
+   |---|---|
+   | Send Messages | Nachrichten in Channels posten |
+   | Embed Links | Discord Embeds rendern |
+   | Use External Emojis | Custom Emojis in Messages |
+   | Manage Messages | Sticky-Message-Updates (alte Nachricht löschen, neue posten) |
+   | Read Message History | Channel-History für Context lesen |
+   | Mention @here/@everyone | Eskalations-Alerts |
+
+4. Generierte URL am Ende der Seite kopieren
+5. URL im Browser öffnen
+6. Server auswählen: **Nathan Ops** (Nicos Guild)
+7. "Authorize" → CAPTCHA bestätigen
+
+Bot erscheint jetzt als Mitglied in "Nathan Ops".
+
+---
+
+## Schritt 4 — Guild ID kopieren
+
+1. In Discord: **Developer Mode** einschalten
+   - User Settings → Advanced → Developer Mode = ON
+2. Rechtsklick auf den **Nathan Ops** Server-Icon
+3. **"Copy Server ID"** → `DISCORD_GUILD_ID` in `~/.openclaw/.env`
+
+```bash
+# ~/.openclaw/.env ergänzen:
+DISCORD_GUILD_ID=<Server ID>
+```
+
+---
+
+## Schritt 5 — Ed25519 Public Key notieren
+
+Der Public Key wurde bereits in Schritt 1 kopiert. Er wird später in Schritt 6 für die
+"Interactions Endpoint URL" Verification benötigt — Discord schickt beim Eintragen des Endpoints
+einen Signed-Ping, den `ai-review-callback.json` Workflow via Ed25519 verifiziert.
+
+Sicherstellen, dass `DISCORD_PUBLIC_KEY` korrekt in `~/.openclaw/.env` steht.
+
+---
+
+## Schritt 6 — Interactions Endpoint URL eintragen (NACH setup.sh)
+
+Dieser Schritt erfolgt NACH dem Ausführen von `setup.sh` (Tailscale Funnel muss laufen).
+
+1. Zurück im Developer Portal → General Information
+2. Feld "Interactions Endpoint URL":
+   ```
+   https://r2d2.tail4fc6dd.ts.net/webhook/discord-interaction
+   ```
+3. "Save Changes" klicken
+4. Discord verifiziert den Endpoint sofort — wenn `ai-review-callback.json` Workflow
+   aktiv und Tailscale Funnel läuft, erscheint "URL successfully verified"
+
+> Falls Verification fehlschlägt: prüfen ob ops-n8n läuft (`docker ps | grep ops-n8n`),
+> Tailscale Funnel aktiv ist (`sudo tailscale funnel status`) und der Workflow aktiviert ist.
+
+---
+
+## Verify: Bot-Mitgliedschaft und API-Verbindung prüfen
+
+```bash
+# Voraussetzung: DISCORD_BOT_TOKEN in Shell exportiert (oder direkt aus env lesen)
+source ~/.openclaw/.env
+
+# Guild-Mitgliedschaft verifizieren — erwartet: Guild-Objekt mit name="Nathan Ops"
+curl -s -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+  "https://discord.com/api/v10/guilds/$DISCORD_GUILD_ID" \
+  | python3 -m json.tool | grep '"name"'
+
+# Bot-User verifizieren — erwartet: {"username":"Nathan Ops Bot",...}
+curl -s -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+  "https://discord.com/api/v10/users/@me" \
+  | python3 -m json.tool | grep '"username"'
+```
+
+Erwartete Outputs:
+- `"name": "Nathan Ops"` (Guild-Name)
+- `"username": "Nathan Ops Bot"` (Bot-Name)
+
+---
+
+## Zusammenfassung: Env-Vars Checkliste
+
+| Variable | Quelle | Status |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | Bot Tab → Reset Token | [ ] |
+| `DISCORD_APPLICATION_ID` | General Information → Application ID | [ ] |
+| `DISCORD_PUBLIC_KEY` | General Information → Public Key | [ ] |
+| `DISCORD_GUILD_ID` | Discord Dev Mode → Server ID | [ ] |
+
+Sobald alle 4 gesetzt sind: `bash ops/discord-bot/setup.sh` ausführen.

--- a/ops/discord-bot/setup.sh
+++ b/ops/discord-bot/setup.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# setup.sh — One-Shot Setup: Discord Bot + ops-n8n + Tailscale Funnel
+#
+# Orchestriert:
+#   1. Preflight Checks (Tools vorhanden?)
+#   2. Discord Channels provisionieren (provision_channels.py)
+#   3. ops-n8n Docker-Container starten
+#   4. Warten bis ops-n8n healthy
+#   5. n8n Workflows importieren
+#   6. Tailscale Funnel für Discord Interactions Endpoint konfigurieren
+#   7. Finale Anweisungen ausgeben
+#
+# Voraussetzung:
+#   - ~/.openclaw/.env enthält DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, N8N_API_KEY
+#   - tailscale is installed and authenticated on r2d2
+#   - docker + docker compose v2 installed
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()      { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+die() {
+    log_error "$*"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Pfade (relativ zum Repo-Root ermitteln)
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OPS_DIR="$REPO_ROOT/ops"
+N8N_DIR="$OPS_DIR/n8n"
+BOT_DIR="$OPS_DIR/discord-bot"
+ENV_FILE="$HOME/.openclaw/.env"
+
+# ---------------------------------------------------------------------------
+# Schritt 0: Env-Datei laden
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    die "~/.openclaw/.env nicht gefunden. Bitte anlegen (siehe register-bot.md)."
+fi
+
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+
+# ---------------------------------------------------------------------------
+# Schritt 1: Preflight — benötigte Tools prüfen
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 1: Preflight Checks ==="
+
+check_cmd() {
+    local cmd="$1"
+    local hint="${2:-}"
+    if ! command -v "$cmd" &>/dev/null; then
+        log_error "Tool nicht gefunden: $cmd${hint:+ — $hint}"
+        return 1
+    fi
+    log_ok "$cmd gefunden: $(command -v "$cmd")"
+}
+
+preflight_ok=true
+check_cmd python3                   "apt install python3"         || preflight_ok=false
+check_cmd curl                      "apt install curl"            || preflight_ok=false
+check_cmd docker                    "siehe docs/docker-setup.md"  || preflight_ok=false
+check_cmd tailscale                 "apt install tailscale"       || preflight_ok=false
+
+# docker compose v2 check
+if ! docker compose version &>/dev/null; then
+    log_error "docker compose v2 nicht verfügbar (docker compose version fehlgeschlagen)"
+    preflight_ok=false
+else
+    log_ok "docker compose v2 verfügbar"
+fi
+
+# pip3 / requests check für provision_channels.py
+if ! python3 -c "import requests" 2>/dev/null; then
+    log_warn "Python requests nicht installiert. Installiere via pip3..."
+    pip3 install --user requests || die "pip3 install requests fehlgeschlagen"
+fi
+
+if [[ "$preflight_ok" != "true" ]]; then
+    die "Preflight fehlgeschlagen. Bitte fehlende Tools installieren und erneut versuchen."
+fi
+
+# Pflicht-Env-Vars prüfen
+for var in DISCORD_BOT_TOKEN DISCORD_GUILD_ID N8N_API_KEY; do
+    if [[ -z "${!var:-}" ]]; then
+        die "Env-Var $var nicht gesetzt in $ENV_FILE. Bitte register-bot.md befolgen."
+    fi
+done
+log_ok "Alle Pflicht-Env-Vars gesetzt."
+
+# ---------------------------------------------------------------------------
+# Schritt 2: Discord Channels provisionieren
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 2: Discord Channels provisionieren ==="
+
+PROJECTS="ai-portal,nathan-cockpit,openclaw-office,research-workflow-n8n,ai-review-pipeline"
+
+python3 "$BOT_DIR/provision_channels.py" \
+    --guild-id "$DISCORD_GUILD_ID" \
+    --projects "$PROJECTS" \
+    || {
+        log_warn "provision_channels.py hat mit nicht-0 Exit beendet (fehlgeschlagene Channels)."
+        log_warn "Bitte Logs prüfen und ggf. fehlende Channels manuell anlegen."
+        # Fail-Open: setup.sh läuft weiter
+    }
+
+log_ok "Channel-Provisioning abgeschlossen."
+
+# ---------------------------------------------------------------------------
+# Schritt 3: ops-n8n Docker-Container starten
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 3: ops-n8n Container starten ==="
+
+if [[ ! -f "$N8N_DIR/docker-compose.yml" ]]; then
+    die "docker-compose.yml nicht gefunden: $N8N_DIR/docker-compose.yml"
+fi
+
+docker compose -f "$N8N_DIR/docker-compose.yml" up -d
+log_ok "ops-n8n Container gestartet."
+
+# ---------------------------------------------------------------------------
+# Schritt 4: Warten bis ops-n8n healthy
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 4: Warten auf ops-n8n Health ==="
+
+N8N_HEALTH_URL="http://127.0.0.1:5679/healthz"
+MAX_WAIT=60
+WAITED=0
+INTERVAL=3
+
+log_info "Prüfe $N8N_HEALTH_URL (max ${MAX_WAIT}s) ..."
+
+until curl -sf "$N8N_HEALTH_URL" &>/dev/null; do
+    if [[ $WAITED -ge $MAX_WAIT ]]; then
+        die "ops-n8n ist nach ${MAX_WAIT}s noch nicht healthy. Prüfe: docker logs ops-n8n"
+    fi
+    echo -n "."
+    sleep "$INTERVAL"
+    WAITED=$((WAITED + INTERVAL))
+done
+echo ""
+log_ok "ops-n8n ist healthy (nach ${WAITED}s)."
+
+# ---------------------------------------------------------------------------
+# Schritt 5: Workflows importieren
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 5: n8n Workflows importieren ==="
+
+if [[ ! -f "$N8N_DIR/scripts/setup-ops-n8n.sh" ]]; then
+    die "setup-ops-n8n.sh nicht gefunden: $N8N_DIR/scripts/setup-ops-n8n.sh"
+fi
+
+bash "$N8N_DIR/scripts/setup-ops-n8n.sh" --import-only
+log_ok "Workflows importiert."
+
+# ---------------------------------------------------------------------------
+# Schritt 6: Tailscale Funnel für Discord Interactions Endpoint
+# ---------------------------------------------------------------------------
+
+log_info "=== Schritt 6: Tailscale Funnel konfigurieren ==="
+
+log_info "Aktiviere Tailscale Funnel für /webhook/discord-interaction → localhost:5679 ..."
+sudo tailscale funnel --bg --set-path /webhook/discord-interaction localhost:5679
+log_ok "Tailscale Funnel aktiv."
+
+# Tailscale-Hostname ermitteln
+TAILSCALE_HOSTNAME=$(tailscale status --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('Self',{}).get('DNSName','').rstrip('.'))" 2>/dev/null || echo "r2d2.tail4fc6dd.ts.net")
+INTERACTIONS_URL="https://${TAILSCALE_HOSTNAME}/webhook/discord-interaction"
+
+# ---------------------------------------------------------------------------
+# Schritt 7: Finale Anweisungen
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "============================================================"
+echo -e "${GREEN}Setup abgeschlossen!${NC}"
+echo "============================================================"
+echo ""
+echo "Letzter manueller Schritt:"
+echo ""
+echo "  Discord Developer Portal → Deine Application → General Information"
+echo "  → 'Interactions Endpoint URL' setzen auf:"
+echo ""
+echo -e "    ${YELLOW}${INTERACTIONS_URL}${NC}"
+echo ""
+echo "  Dann 'Save Changes' klicken."
+echo "  Discord verifiziert den Endpoint sofort."
+echo ""
+echo "------------------------------------------------------------"
+echo "Kanäle erstellt für Projekte: $PROJECTS"
+echo "ops-n8n läuft auf:            http://127.0.0.1:5679"
+echo "n8n UI erreichbar via:        http://127.0.0.1:5679 (lokal)"
+echo "Tailscale Funnel URL:         $INTERACTIONS_URL"
+echo "------------------------------------------------------------"
+echo ""
+log_ok "Fertig. Viel Spass mit dem Discord Bot!"

--- a/ops/n8n/docker-compose.yml
+++ b/ops/n8n/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.9"
+
+# ops-n8n — Globale Messaging-Bridge für AI-Review-Pipeline
+# Port 5679 (5678 bleibt bei ai-portal-n8n für Business-Workflows)
+# Image: n8nio/n8n:latest (kein Custom-Build)
+# Volume: ops-n8n-data (Credentials + Workflow-Storage)
+# Env-File: ~/.openclaw/.env (geteilte Secrets)
+
+services:
+  ops-n8n:
+    image: n8nio/n8n:latest
+    container_name: ops-n8n
+    restart: unless-stopped
+    ports:
+      - "5679:5678"
+    env_file:
+      - ${HOME}/.openclaw/.env
+    environment:
+      # n8n interne Config
+      N8N_HOST: "0.0.0.0"
+      N8N_PORT: "5678"
+      N8N_PROTOCOL: "http"
+      # Execution Timeout: 600s — parallele Reviewer-Execs (Plan §731 R10)
+      N8N_EXECUTION_TIMEOUT: "600"
+      # Webhook-URL (für Tailscale-Funnel-External-URL)
+      WEBHOOK_URL: "https://r2d2.tail4fc6dd.ts.net"
+      # API aktivieren (für Import-Scripts)
+      N8N_API_ALLOWED_ORIGINS: "*"
+      N8N_METRICS: "true"
+      # Log-Level
+      N8N_LOG_LEVEL: "info"
+      # Task Runner Heartbeat (verhindert Timeout bei langen LLM-Calls)
+      N8N_RUNNERS_HEARTBEAT_INTERVAL: "300"
+      OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS: "false"
+    volumes:
+      - ops-n8n-data:/home/node/.n8n
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://127.0.0.1:5678/healthz",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  ops-n8n-data:
+    name: ops-n8n-data

--- a/ops/n8n/scripts/backup-ops-n8n.sh
+++ b/ops/n8n/scripts/backup-ops-n8n.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# backup-ops-n8n.sh — Wöchentliches Backup der ops-n8n Workflows + Credential-IDs
+#
+# Cron-kompatibel (wöchentlich):
+#   0 3 * * 0 /home/clawd/projects/agent-stack/ops/n8n/scripts/backup-ops-n8n.sh
+#
+# Exportiert:
+#   - Alle Workflows als JSON (via n8n REST API)
+#   - Credential-IDs als Liste (keine Werte — Security!)
+#   - Paketiert als tarball in ~/.openclaw/backups/ops-n8n/
+#
+# Benötigt:
+#   - N8N_API_KEY in ~/.openclaw/.env
+#   - ops-n8n Container läuft (http://127.0.0.1:5679 erreichbar)
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()       { log_error "$*"; exit 1; }
+
+# Env laden
+ENV_FILE="$HOME/.openclaw/.env"
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+N8N_API_KEY="${N8N_API_KEY:-}"
+N8N_API_BASE="http://127.0.0.1:5679/api/v1"
+BACKUP_BASE="$HOME/.openclaw/backups/ops-n8n"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$BACKUP_BASE/$TIMESTAMP"
+
+mkdir -p "$BACKUP_DIR"
+
+# Erreichbarkeit prüfen
+if ! curl -sf "http://127.0.0.1:5679/healthz" &>/dev/null; then
+    die "ops-n8n nicht erreichbar (http://127.0.0.1:5679/healthz). Container läuft?"
+fi
+
+if [[ -z "$N8N_API_KEY" ]]; then
+    die "N8N_API_KEY nicht gesetzt in $ENV_FILE. Backup nicht möglich."
+fi
+
+log_info "Backup gestartet: $BACKUP_DIR"
+
+# --- Workflows exportieren ---
+log_info "Exportiere Workflows ..."
+
+WORKFLOWS_RESPONSE=$(curl -s \
+    -H "X-N8N-API-KEY: $N8N_API_KEY" \
+    "$N8N_API_BASE/workflows" 2>/dev/null)
+
+if [[ -z "$WORKFLOWS_RESPONSE" ]]; then
+    die "Keine Antwort von n8n API. API-Key korrekt?"
+fi
+
+# Alle Workflows als einzelne JSONs + Gesamtliste
+echo "$WORKFLOWS_RESPONSE" > "$BACKUP_DIR/workflows-all.json"
+
+# Pro Workflow einzelne Datei
+WF_COUNT=$(echo "$WORKFLOWS_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+workflows = data if isinstance(data, list) else data.get('data', [])
+for wf in workflows:
+    name = wf.get('name','unknown').replace(' ', '-').replace('/', '-')
+    wf_id = wf.get('id', 'unknown')
+    safe_name = ''.join(c for c in name if c.isalnum() or c in '-_')
+    filename = f'{safe_name}-{wf_id}.json'
+    with open('${BACKUP_DIR}/' + filename, 'w') as f:
+        json.dump(wf, f, indent=2)
+print(len(workflows))
+" 2>/dev/null || echo "0")
+
+log_ok "Workflows exportiert: $WF_COUNT Files."
+
+# --- Credential-IDs exportieren (keine Werte!) ---
+log_info "Exportiere Credential-IDs (keine Werte) ..."
+
+CREDS_RESPONSE=$(curl -s \
+    -H "X-N8N-API-KEY: $N8N_API_KEY" \
+    "$N8N_API_BASE/credentials" 2>/dev/null)
+
+if [[ -n "$CREDS_RESPONSE" ]]; then
+    echo "$CREDS_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+creds = data if isinstance(data, list) else data.get('data', [])
+# Nur IDs + Namen exportieren, KEINE Werte
+safe_creds = [{'id': c.get('id'), 'name': c.get('name'), 'type': c.get('type')} for c in creds]
+print(json.dumps(safe_creds, indent=2))
+" > "$BACKUP_DIR/credential-ids.json" 2>/dev/null || echo "[]" > "$BACKUP_DIR/credential-ids.json"
+    log_ok "Credential-IDs exportiert."
+else
+    log_warn "Keine Credentials gefunden oder API-Fehler."
+    echo "[]" > "$BACKUP_DIR/credential-ids.json"
+fi
+
+# --- Tarball erstellen ---
+log_info "Erstelle Tarball ..."
+TARBALL="$BACKUP_BASE/ops-n8n-backup-$TIMESTAMP.tar.gz"
+tar -czf "$TARBALL" -C "$BACKUP_BASE" "$TIMESTAMP"
+log_ok "Tarball: $TARBALL"
+
+# Backup-Verzeichnis aufräumen (nur Tarball behalten)
+rm -rf "$BACKUP_DIR"
+
+# --- Alte Backups bereinigen (älter als 30 Tage) ---
+find "$BACKUP_BASE" -name "ops-n8n-backup-*.tar.gz" -mtime +30 -delete 2>/dev/null \
+    && log_info "Alte Backups (>30 Tage) bereinigt." \
+    || true
+
+log_ok "Backup abgeschlossen: $TARBALL"
+log_info "Inhalt: $WF_COUNT Workflows, Credential-IDs (ohne Werte)"

--- a/ops/n8n/scripts/backup-ops-n8n.sh
+++ b/ops/n8n/scripts/backup-ops-n8n.sh
@@ -29,6 +29,7 @@ die()       { log_error "$*"; exit 1; }
 
 # Env laden
 ENV_FILE="$HOME/.openclaw/.env"
+# shellcheck source=/dev/null
 [[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
 
 N8N_API_KEY="${N8N_API_KEY:-}"
@@ -113,9 +114,9 @@ log_ok "Tarball: $TARBALL"
 rm -rf "$BACKUP_DIR"
 
 # --- Alte Backups bereinigen (älter als 30 Tage) ---
-find "$BACKUP_BASE" -name "ops-n8n-backup-*.tar.gz" -mtime +30 -delete 2>/dev/null \
-    && log_info "Alte Backups (>30 Tage) bereinigt." \
-    || true
+if find "$BACKUP_BASE" -name "ops-n8n-backup-*.tar.gz" -mtime +30 -delete 2>/dev/null; then
+    log_info "Alte Backups (>30 Tage) bereinigt."
+fi
 
 log_ok "Backup abgeschlossen: $TARBALL"
 log_info "Inhalt: $WF_COUNT Workflows, Credential-IDs (ohne Werte)"

--- a/ops/n8n/scripts/setup-ops-n8n.sh
+++ b/ops/n8n/scripts/setup-ops-n8n.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# setup-ops-n8n.sh — ops-n8n Container starten + Workflows importieren
+#
+# Verwendung:
+#   bash ops/n8n/scripts/setup-ops-n8n.sh           # start + import
+#   bash ops/n8n/scripts/setup-ops-n8n.sh --import-only  # nur import (Container läuft schon)
+#
+# Benötigt:
+#   - docker + docker compose v2
+#   - N8N_API_KEY in ~/.openclaw/.env (nach erstem Start in n8n UI generieren)
+#   - WORKFLOWS_DIR: ops/n8n/workflows/ mit den 3 JSON-Files
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()       { log_error "$*"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+N8N_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$N8N_DIR/docker-compose.yml"
+WORKFLOWS_DIR="$N8N_DIR/workflows"
+ENV_FILE="$HOME/.openclaw/.env"
+
+# Flags
+IMPORT_ONLY=false
+for arg in "$@"; do
+    [[ "$arg" == "--import-only" ]] && IMPORT_ONLY=true
+done
+
+# Env laden
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+# --- Schritt 1: Container starten (wenn nicht --import-only) ---
+if [[ "$IMPORT_ONLY" == "false" ]]; then
+    log_info "Starte ops-n8n Container ..."
+    docker compose -f "$COMPOSE_FILE" up -d
+    log_ok "Container gestartet."
+
+    # Auf Health warten
+    log_info "Warte auf ops-n8n Health (http://127.0.0.1:5679/healthz) ..."
+    MAX_WAIT=90
+    WAITED=0
+    until curl -sf "http://127.0.0.1:5679/healthz" &>/dev/null; do
+        [[ $WAITED -ge $MAX_WAIT ]] && die "ops-n8n nicht healthy nach ${MAX_WAIT}s. docker logs ops-n8n"
+        echo -n "."
+        sleep 3
+        WAITED=$((WAITED + 3))
+    done
+    echo ""
+    log_ok "ops-n8n healthy (nach ${WAITED}s)."
+fi
+
+# --- Schritt 2: Workflows importieren via n8n REST API ---
+N8N_API_BASE="http://127.0.0.1:5679/api/v1"
+N8N_API_KEY="${N8N_API_KEY:-}"
+
+if [[ -z "$N8N_API_KEY" ]]; then
+    log_warn "N8N_API_KEY nicht gesetzt."
+    log_warn "Bitte in n8n UI generieren: Einstellungen → API → API Key erstellen"
+    log_warn "Dann N8N_API_KEY in ~/.openclaw/.env setzen und erneut ausführen."
+    log_warn "Workflows werden NICHT importiert."
+    exit 0
+fi
+
+log_info "Importiere Workflows aus $WORKFLOWS_DIR ..."
+
+IMPORTED=0
+FAILED=0
+
+for wf_file in "$WORKFLOWS_DIR"/*.json; do
+    [[ -f "$wf_file" ]] || continue
+    wf_name="$(basename "$wf_file")"
+
+    log_info "  Importiere: $wf_name ..."
+
+    HTTP_STATUS=$(curl -s -o /tmp/n8n-import-response.json -w "%{http_code}" \
+        -X POST \
+        -H "X-N8N-API-KEY: $N8N_API_KEY" \
+        -H "Content-Type: application/json" \
+        --data-binary "@$wf_file" \
+        "$N8N_API_BASE/workflows" 2>/dev/null)
+
+    if [[ "$HTTP_STATUS" == "200" ]] || [[ "$HTTP_STATUS" == "201" ]]; then
+        WF_ID=$(python3 -c "import json,sys; d=json.load(open('/tmp/n8n-import-response.json')); print(d.get('id','?'))" 2>/dev/null || echo "?")
+        log_ok "    $wf_name → id=$WF_ID (HTTP $HTTP_STATUS)"
+        IMPORTED=$((IMPORTED + 1))
+
+        # Workflow aktivieren
+        if [[ "$WF_ID" != "?" ]]; then
+            curl -s -o /dev/null \
+                -X PATCH \
+                -H "X-N8N-API-KEY: $N8N_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{"active": true}' \
+                "$N8N_API_BASE/workflows/$WF_ID" 2>/dev/null \
+                && log_ok "    $wf_name aktiviert." \
+                || log_warn "    $wf_name konnte nicht aktiviert werden (Aktivierung separat in n8n UI nötig)."
+        fi
+    else
+        log_error "    $wf_name fehlgeschlagen (HTTP $HTTP_STATUS)"
+        cat /tmp/n8n-import-response.json 2>/dev/null | python3 -m json.tool 2>/dev/null || true
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+log_info "Import abgeschlossen: $IMPORTED importiert, $FAILED fehlgeschlagen."
+
+[[ $FAILED -gt 0 ]] && log_warn "Einige Workflows konnten nicht importiert werden. Bitte n8n UI prüfen."
+
+log_ok "setup-ops-n8n.sh fertig."

--- a/ops/n8n/scripts/setup-ops-n8n.sh
+++ b/ops/n8n/scripts/setup-ops-n8n.sh
@@ -37,6 +37,7 @@ for arg in "$@"; do
 done
 
 # Env laden
+# shellcheck source=/dev/null
 [[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
 
 # --- Schritt 1: Container starten (wenn nicht --import-only) ---
@@ -96,18 +97,20 @@ for wf_file in "$WORKFLOWS_DIR"/*.json; do
 
         # Workflow aktivieren
         if [[ "$WF_ID" != "?" ]]; then
-            curl -s -o /dev/null \
+            if curl -s -o /dev/null \
                 -X PATCH \
                 -H "X-N8N-API-KEY: $N8N_API_KEY" \
                 -H "Content-Type: application/json" \
                 -d '{"active": true}' \
-                "$N8N_API_BASE/workflows/$WF_ID" 2>/dev/null \
-                && log_ok "    $wf_name aktiviert." \
-                || log_warn "    $wf_name konnte nicht aktiviert werden (Aktivierung separat in n8n UI nötig)."
+                "$N8N_API_BASE/workflows/$WF_ID" 2>/dev/null; then
+                log_ok "    $wf_name aktiviert."
+            else
+                log_warn "    $wf_name konnte nicht aktiviert werden (Aktivierung separat in n8n UI nötig)."
+            fi
         fi
     else
         log_error "    $wf_name fehlgeschlagen (HTTP $HTTP_STATUS)"
-        cat /tmp/n8n-import-response.json 2>/dev/null | python3 -m json.tool 2>/dev/null || true
+        python3 -m json.tool < /tmp/n8n-import-response.json 2>/dev/null || true
         FAILED=$((FAILED + 1))
     fi
 done

--- a/ops/n8n/workflows/ai-review-callback.json
+++ b/ops/n8n/workflows/ai-review-callback.json
@@ -1,0 +1,359 @@
+{
+  "id": "ai-review-callback",
+  "name": "[AI-Review] Discord Interaction \u2192 GitHub Action",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "tags": [
+    { "name": "ai-review" },
+    { "name": "notifications" },
+    { "name": "discord" }
+  ],
+  "nodes": [
+    {
+      "id": "webhook-interaction",
+      "name": "Receive Discord Interaction",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 260],
+      "webhookId": "discord-interaction",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord-interaction",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "ed25519-verify",
+      "name": "Ed25519 Signature Verify",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [540, 260],
+      "parameters": {
+        "jsCode": "// Ed25519 Signature Verification f\u00fcr Discord Interactions.\n// Discord POSTet bei jedem Interaction (Button-Click ODER Ping-Verify) mit:\n//   Header: X-Signature-Ed25519  (hex-encoded Signatur)\n//   Header: X-Signature-Timestamp (Unix Timestamp als String)\n//   Body: raw JSON string\n//\n// Verify-Pflicht (Plan §670, Discord Docs):\n//   message = timestamp_bytes + body_bytes\n//   verify(signature, message, DISCORD_PUBLIC_KEY)\n//\n// Falls Verify fehlschl\u00e4gt \u2192 401 sofort zur\u00fcckgeben.\n// Falls Interaction Type == 1 (PING) \u2192 {type:1} zur\u00fcckgeben (Endpoint-Verify).\n//\n// ACHTUNG: n8n liefert headers in $json.headers, body in $json.body.\n// Wir nutzen Node.js crypto.subtle f\u00fcr Ed25519 (WebCrypto API in n8n >= 1.x).\n\nconst headers   = $json.headers ?? {};\nconst body      = $json.body ?? {};\nconst rawBody   = $json.rawBody ?? JSON.stringify(body);\n\nconst signature  = headers['x-signature-ed25519'] ?? headers['X-Signature-Ed25519'] ?? '';\nconst timestamp  = headers['x-signature-timestamp'] ?? headers['X-Signature-Timestamp'] ?? '';\nconst publicKey  = $env.DISCORD_PUBLIC_KEY ?? '';\n\nif (!publicKey) {\n  throw new Error('DISCORD_PUBLIC_KEY nicht gesetzt in n8n env. Bitte ~/.openclaw/.env pr\u00fcfen.');\n}\n\n// --- Signature Verify via WebCrypto (Ed25519) ---\nlet verifyOk = false;\ntry {\n  const encoder = new TextEncoder();\n  const msgBytes = encoder.encode(timestamp + rawBody);\n  const sigBytes = Uint8Array.from(Buffer.from(signature, 'hex'));\n  const keyBytes = Uint8Array.from(Buffer.from(publicKey, 'hex'));\n\n  const cryptoKey = await crypto.subtle.importKey(\n    'raw',\n    keyBytes,\n    { name: 'Ed25519' },\n    false,\n    ['verify'],\n  );\n\n  verifyOk = await crypto.subtle.verify(\n    { name: 'Ed25519' },\n    cryptoKey,\n    sigBytes,\n    msgBytes,\n  );\n} catch (err) {\n  // Malformed signature oder fehlende WebCrypto-Unterst\u00fctzung\n  verifyOk = false;\n}\n\nif (!verifyOk) {\n  return [{\n    json: {\n      _action: 'reject',\n      _reason: 'Ed25519 signature verification failed',\n      _http_status: 401,\n    },\n  }];\n}\n\n// --- Interaction Type Check ---\nconst interactionType = body.type ?? 0;\n\n// Type 1 = PING (Discord verifiziert den Endpoint beim Eintragen der URL)\nif (interactionType === 1) {\n  return [{\n    json: {\n      _action: 'pong',\n      _pong_response: { type: 1 },  // ACK Discord PING\n    },\n  }];\n}\n\n// Type 3 = MESSAGE_COMPONENT (Button-Click)\nif (interactionType === 3) {\n  const customId = body.data?.custom_id ?? '';\n  const userId   = body.member?.user?.id ?? body.user?.id ?? '';\n  const interactionId    = body.id ?? '';\n  const interactionToken = body.token ?? '';\n\n  // custom_id Format: 'action:pr_number'\n  const parts = customId.split(':');\n  if (parts.length !== 2) {\n    return [{\n      json: {\n        _action: 'invalid',\n        _reason: `custom_id malformed: '${customId}' (expected 'action:pr_number')`,\n        interaction_id: interactionId,\n        interaction_token: interactionToken,\n      },\n    }];\n  }\n\n  const [actionRaw, prRaw] = parts;\n  const action = actionRaw.toLowerCase().trim();\n  const prNumber = parseInt(prRaw, 10);\n\n  if (!Number.isFinite(prNumber) || prNumber <= 0) {\n    return [{\n      json: {\n        _action: 'invalid',\n        _reason: `pr_number malformed: '${prRaw}'`,\n        interaction_id: interactionId,\n        interaction_token: interactionToken,\n      },\n    }];\n  }\n\n  if (!['approve', 'fix', 'manual'].includes(action)) {\n    return [{\n      json: {\n        _action: 'invalid',\n        _reason: `unknown action: '${action}'`,\n        interaction_id: interactionId,\n        interaction_token: interactionToken,\n      },\n    }];\n  }\n\n  return [{\n    json: {\n      _action: action,\n      pr_number: prNumber,\n      user_id: userId,\n      interaction_id: interactionId,\n      interaction_token: interactionToken,\n    },\n  }];\n}\n\n// Unbekannter Interaction Type\nreturn [{\n  json: {\n    _action: 'noop',\n    _reason: `unhandled interaction type: ${interactionType}`,\n  },\n}];\n"
+      }
+    },
+    {
+      "id": "reject-check",
+      "name": "Reject: 401 on Sig Failure",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [860, 160],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json._action }}",
+              "rightValue": "reject",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      }
+    },
+    {
+      "id": "respond-401",
+      "name": "Respond 401 Unauthorized",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 80],
+      "parameters": {
+        "respondWith": "json",
+        "responseCode": 401,
+        "responseBody": "={{ { error: 'invalid_signature' } }}"
+      }
+    },
+    {
+      "id": "pong-check",
+      "name": "PING? → Respond PONG",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [860, 320],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json._action }}",
+              "rightValue": "pong",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      }
+    },
+    {
+      "id": "respond-pong",
+      "name": "Respond PONG (type:1)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 260],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json._pong_response }}"
+      }
+    },
+    {
+      "id": "dispatch-switch",
+      "name": "Dispatch by Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1060, 480],
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": { "caseSensitive": true, "typeValidation": "loose" },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json._action }}",
+                    "rightValue": "approve",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "approve"
+            },
+            {
+              "conditions": {
+                "options": { "caseSensitive": true, "typeValidation": "loose" },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json._action }}",
+                    "rightValue": "fix",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "fix"
+            },
+            {
+              "conditions": {
+                "options": { "caseSensitive": true, "typeValidation": "loose" },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json._action }}",
+                    "rightValue": "manual",
+                    "operator": { "type": "string", "operation": "equals" }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "manual"
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra"
+        }
+      }
+    },
+    {
+      "id": "action-approve",
+      "name": "Action: Approve (PR comment /ai-review approve)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1360, 360],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://api.github.com/repos/' + $env.GITHUB_REPO + '/issues/' + $json.pr_number + '/comments' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github+json" },
+            { "name": "Authorization", "value": "=Bearer {{ $env.GITHUB_TOKEN }}" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { body: '/ai-review approve' } }}",
+        "options": { "timeout": 10000 }
+      }
+    },
+    {
+      "id": "action-autofix",
+      "name": "Action: Auto-Fix (gh workflow run)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1360, 520],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://api.github.com/repos/' + $env.GITHUB_REPO + '/actions/workflows/ai-review-auto-fix.yml/dispatches' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github+json" },
+            { "name": "Authorization", "value": "=Bearer {{ $env.GITHUB_TOKEN }}" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { ref: 'main', inputs: { pr_number: String($json.pr_number), reason: 'discord-button', context_hint: 'Nico hat Auto-Fix im Discord getippt', max_files: '10' } } }}",
+        "options": { "timeout": 10000 }
+      }
+    },
+    {
+      "id": "action-manual",
+      "name": "Action: Manual Review (label + comment)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1360, 680],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://api.github.com/repos/' + $env.GITHUB_REPO + '/issues/' + $json.pr_number + '/labels' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github+json" },
+            { "name": "Authorization", "value": "=Bearer {{ $env.GITHUB_TOKEN }}" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ ['needs-human-review'] }}",
+        "options": { "timeout": 10000 }
+      }
+    },
+    {
+      "id": "ack-interaction",
+      "name": "ACK Discord Interaction (deferred update)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1660, 520],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://discord.com/api/v10/interactions/' + $('Dispatch by Action').item.json.interaction_id + '/' + $('Dispatch by Action').item.json.interaction_token + '/callback' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bot {{ $env.DISCORD_BOT_TOKEN }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { type: 6 } }}",
+        "options": { "timeout": 10000 }
+      },
+      "notes": "type:6 = DEFERRED_UPDATE_MESSAGE — zeigt Discord keinen Loading-State, best practice f\u00fcr Bot-Actions die >3s dauern (GitHub API Call)"
+    },
+    {
+      "id": "respond-ok",
+      "name": "Respond 200 OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1860, 520],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { ok: true, action: $('Dispatch by Action').item.json._action, pr: $('Dispatch by Action').item.json.pr_number } }}"
+      }
+    }
+  ],
+  "connections": {
+    "Receive Discord Interaction": {
+      "main": [
+        [
+          { "node": "Ed25519 Signature Verify", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Ed25519 Signature Verify": {
+      "main": [
+        [
+          { "node": "Reject: 401 on Sig Failure", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Reject: 401 on Sig Failure": {
+      "main": [
+        [
+          { "node": "Respond 401 Unauthorized", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "PING? \u2192 Respond PONG", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "PING? \u2192 Respond PONG": {
+      "main": [
+        [
+          { "node": "Respond PONG (type:1)", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Dispatch by Action", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Dispatch by Action": {
+      "main": [
+        [
+          { "node": "Action: Approve (PR comment /ai-review approve)", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Action: Auto-Fix (gh workflow run)", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Action: Manual Review (label + comment)", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "ACK Discord Interaction (deferred update)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Action: Approve (PR comment /ai-review approve)": {
+      "main": [
+        [
+          { "node": "ACK Discord Interaction (deferred update)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Action: Auto-Fix (gh workflow run)": {
+      "main": [
+        [
+          { "node": "ACK Discord Interaction (deferred update)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Action: Manual Review (label + comment)": {
+      "main": [
+        [
+          { "node": "ACK Discord Interaction (deferred update)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "ACK Discord Interaction (deferred update)": {
+      "main": [
+        [
+          { "node": "Respond 200 OK", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  }
+}

--- a/ops/n8n/workflows/ai-review-dispatcher.json
+++ b/ops/n8n/workflows/ai-review-dispatcher.json
@@ -1,0 +1,116 @@
+{
+  "id": "ai-review-dispatcher",
+  "name": "[AI-Review] Dispatcher \u2192 Discord Components v2",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "tags": [
+    { "name": "ai-review" },
+    { "name": "notifications" },
+    { "name": "discord" }
+  ],
+  "nodes": [
+    {
+      "id": "webhook-dispatch",
+      "name": "Receive Dispatch Payload",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 260],
+      "webhookId": "ai-review-dispatch",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "ai-review-dispatch",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "build-discord-message",
+      "name": "Build Discord Components v2 Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [540, 260],
+      "parameters": {
+        "jsCode": "// Baut eine Discord Components v2 Message mit ActionRow + Inline-Buttons.\n// Input-Schema (von discord_notify.py in ai-review-pipeline):\n//   body.pr_number      string | number\n//   body.pr_url         string (GitHub PR URL)\n//   body.project        string (Projektname)\n//   body.channel_id     string (Discord Channel ID)\n//   body.stage          string (aktuell fehlgeschlagene Stage oder 'dispatch')\n//   body.summary        string (max 500 Zeichen, Review-Summary)\n//   body.avg_score      number (Consensus-Score 0-10)\n//   body.button_actions array [{text, custom_id}] — optional, override Standard-Buttons\n//\n// Discord API v10: POST /channels/{channel_id}/messages\n// flags: 32768 = IS_COMPONENTS_V2 (required für Components v2)\n// Ref: https://discord.com/developers/docs/interactions/message-components\n\nconst body = $json.body ?? $json ?? {};\n\nconst prNumber  = String(body.pr_number ?? '?');\nconst prUrl     = String(body.pr_url ?? '');\nconst project   = String(body.project ?? 'unknown');\nconst channelId = String(body.channel_id ?? '');\nconst stage     = String(body.stage ?? 'dispatch');\nconst summary   = String(body.summary ?? '').slice(0, 500);\nconst avgScore  = body.avg_score ?? null;\n\nif (!channelId) {\n  throw new Error('channel_id fehlt im Payload. Bitte .ai-review/config.yaml prüfen.');\n}\n\n// --- Content ---\nconst scoreEmoji = avgScore === null ? '' : avgScore >= 8 ? '\\u2705' : avgScore >= 5 ? '\\u26a0\\ufe0f' : '\\u274c';\nconst scoreLine = avgScore !== null ? `${scoreEmoji} **Score:** ${avgScore}/10` : '';\n\nlet content = [\n  `**AI-Review** \\u2014 Projekt \\`${project}\\` \\u2014 PR #${prNumber}`,\n  scoreLine,\n  stage !== 'dispatch' ? `**Stage:** ${stage}` : '',\n  summary ? `**Summary:**\\n\\`\\`\\`\\n${summary}\\n\\`\\`\\`` : '',\n  prUrl ? `**PR:** ${prUrl}` : '',\n].filter(Boolean).join('\\n');\n\n// --- Buttons ---\n// Standard-Buttons wenn button_actions nicht im Payload\nlet buttons;\nif (Array.isArray(body.button_actions) && body.button_actions.length > 0) {\n  buttons = body.button_actions\n    .filter(a => a && a.text && a.custom_id)\n    .map(a => ({\n      type: 2,           // BUTTON component type\n      style: a.style ?? 1,  // 1=PRIMARY, 2=SECONDARY, 4=DANGER\n      label: a.text,\n      custom_id: a.custom_id,\n    }));\n} else {\n  // Standard: Approve (PRIMARY=1), Auto-Fix (SECONDARY=2), Manual (DANGER=4)\n  buttons = [\n    { type: 2, style: 1, label: 'Approve',  custom_id: `approve:${prNumber}` },\n    { type: 2, style: 2, label: 'Auto-Fix', custom_id: `fix:${prNumber}` },\n    { type: 2, style: 4, label: 'Manual',   custom_id: `manual:${prNumber}` },\n  ];\n}\n\n// --- Payload f\u00fcr Discord API ---\n// flags: 32768 = IS_COMPONENTS_V2\nconst discordPayload = {\n  content,\n  components: [\n    {\n      type: 1,        // ACTION_ROW\n      components: buttons,\n    },\n  ],\n  flags: 32768,\n};\n\nreturn [{\n  json: {\n    channel_id: channelId,\n    discord_payload: discordPayload,\n    pr_number: prNumber,\n    project,\n  },\n}];\n"
+      }
+    },
+    {
+      "id": "post-to-discord",
+      "name": "POST Message to Discord Channel",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [860, 260],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://discord.com/api/v10/channels/' + $json.channel_id + '/messages' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bot {{ $env.DISCORD_BOT_TOKEN }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.discord_payload }}",
+        "options": {
+          "timeout": 10000
+        }
+      }
+    },
+    {
+      "id": "respond-ok",
+      "name": "Respond 200 OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1160, 260],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { ok: true, message_id: $json.id, channel_id: $('Build Discord Components v2 Message').item.json.channel_id, pr: $('Build Discord Components v2 Message').item.json.pr_number } }}"
+      }
+    }
+  ],
+  "connections": {
+    "Receive Dispatch Payload": {
+      "main": [
+        [
+          {
+            "node": "Build Discord Components v2 Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Discord Components v2 Message": {
+      "main": [
+        [
+          {
+            "node": "POST Message to Discord Channel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST Message to Discord Channel": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/ops/n8n/workflows/ai-review-escalation.json
+++ b/ops/n8n/workflows/ai-review-escalation.json
@@ -1,0 +1,96 @@
+{
+  "id": "ai-review-escalation",
+  "name": "[AI-Review] Escalation \u2192 Discord Alert",
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "tags": [
+    { "name": "ai-review" },
+    { "name": "notifications" },
+    { "name": "discord" }
+  ],
+  "nodes": [
+    {
+      "id": "webhook-escalation",
+      "name": "Receive Escalation Payload",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 260],
+      "webhookId": "ai-review-escalation",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "ai-review-escalation",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "format-discord-alert",
+      "name": "Format Discord Alert Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [540, 260],
+      "parameters": {
+        "jsCode": "// Baut eine Discord Alert-Message f\u00fcr den Eskalations-Channel.\n// Input-Schema (von discord_notify.py in ai-review-pipeline):\n//   body.alert_type   'escalation' | 'disagreement' | 'soft_consensus'\n//   body.pr           string | number\n//   body.pr_url       string\n//   body.project      string\n//   body.stage        string (f\u00fcr escalation)\n//   body.iterations   number\n//   body.last_score   number | null\n//   body.summary      string (max 500 Zeichen)\n//   body.runbook_url  string\n//   body.rerun_cmd    string\n//   body.codex        {verdict, score} (f\u00fcr disagreement)\n//   body.cursor       {verdict, score} (f\u00fcr disagreement)\n//   body.avg_score    number (f\u00fcr soft_consensus)\n//   body.codex_score  number (f\u00fcr soft_consensus)\n//   body.cursor_score number (f\u00fcr soft_consensus)\n//   body.options      {approve, retry, timeout_minutes} (f\u00fcr soft_consensus)\n//\n// Ziel-Channel: DISCORD_ALERTS_CHANNEL_ID (aus env) oder body.channel_id\n// Mention: @here bei echten Eskalationen\n\nconst body = $json.body ?? $json ?? {};\n\nconst alertType = body.alert_type ?? body.event ?? 'escalation';\nconst pr        = body.pr ?? '?';\nconst prUrl     = body.pr_url ?? '';\nconst project   = body.project ?? '';\nconst runbook   = body.runbook_url ?? '';\nconst rerun     = body.rerun_cmd ?? '';\n\n// Channel: explizit im Payload oder Fallback auf ALERTS_CHANNEL_ID env-var\nconst channelId = String(\n  body.channel_id ??\n  $env.DISCORD_ALERTS_CHANNEL_ID ??\n  ''\n);\n\nif (!channelId) {\n  throw new Error(\n    'channel_id fehlt im Payload und DISCORD_ALERTS_CHANNEL_ID nicht gesetzt. ' +\n    'Bitte .ai-review/config.yaml oder ~/.openclaw/.env pr\u00fcfen.'\n  );\n}\n\nconst stageEmoji = {\n  code: '\\ud83e\\udd16',\n  'code-cursor': '\\ud83d\\udc31',\n  security: '\\ud83d\\udd12',\n  design: '\\ud83c\\udfa8',\n};\n\nlet content;\nlet shouldMention = true;  // @here bei echten Eskalationen\n\nif (alertType === 'soft_consensus' || alertType === 'ai-review/soft-consensus') {\n  shouldMention = false;  // soft_consensus = keine @here-Mention\n  const codexScore  = body.codex_score ?? '-';\n  const cursorScore = body.cursor_score ?? '-';\n  const avg         = body.avg_score ?? '?';\n  const opts        = body.options ?? {};\n\n  content = [\n    `\\u{1F914} **AI-Review soft-consensus** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `\\u{1F916} Codex: **${codexScore}/10**`,\n    `\\ud83d\\udc31 Cursor: **${cursorScore}/10**`,\n    `\\ud83d\\udcca Avg: **${avg}/10** (soft-zone 5\\u20138)`,\n    '',\n    'Die Code-Reviewer sehen es differenziert. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    '',\n    opts.approve ? `\\u2705 Approve: \\`${opts.approve}\\`` : '',\n    opts.retry   ? `\\ud83d\\udd01 Retry: \\`${opts.retry}\\`` : '',\n    opts.timeout_minutes ? `\\u23f1\\ufe0f Auto-Eskalation in ${opts.timeout_minutes} min` : '',\n    runbook ? `\\ud83d\\udcd6 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else if (alertType === 'disagreement' || alertType === 'ai-review/disagreement') {\n  const codex  = body.codex ?? {};\n  const cursor = body.cursor ?? {};\n  const fmt    = r => `${r.verdict ?? '?'} (${r.score ?? '-'}/10)`;\n\n  content = [\n    `\\u{1F914} **AI-Review Disagreement** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '@here',\n    '',\n    `\\u{1F916} Codex: **${fmt(codex)}**`,\n    `\\ud83d\\udc31 Cursor: **${fmt(cursor)}**`,\n    '',\n    'Die beiden Code-Reviewer sind uneinig. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else {\n  // Standard: Circuit-Breaker Eskalation\n  const stage      = body.stage ?? 'unknown';\n  const iterations = body.iterations ?? '?';\n  const lastScore  = body.last_score ?? null;\n  const summary    = String(body.summary ?? '').slice(0, 500);\n  const stageE     = stageEmoji[stage] || '\\u2699\\ufe0f';\n  const scoreLine  = lastScore !== null && lastScore !== undefined\n    ? `**Score:** ${lastScore}/10`\n    : '';\n\n  content = [\n    `\\u26a0\\ufe0f **AI Review Escalation** @here`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `${stageE} **Stage:** ${stage}`,\n    `**PR:** #${pr}`,\n    scoreLine,\n    `**Iterations:** ${iterations} (circuit-breaker)`,\n    '',\n    summary ? `**Letzter Hinweis:**\\n\\`\\`\\`\\n${summary}\\n\\`\\`\\`` : '',\n    '',\n    prUrl   ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n}\n\nreturn [{\n  json: {\n    channel_id: channelId,\n    content,\n    alert_type: alertType,\n    pr_number: String(pr),\n  },\n}];\n"
+      }
+    },
+    {
+      "id": "send-discord-alert",
+      "name": "POST Alert to Discord Alerts Channel",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [860, 260],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://discord.com/api/v10/channels/' + $json.channel_id + '/messages' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bot {{ $env.DISCORD_BOT_TOKEN }}" },
+            { "name": "Content-Type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { content: $json.content } }}",
+        "options": { "timeout": 10000 }
+      }
+    },
+    {
+      "id": "respond-ok",
+      "name": "Respond 200 OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1160, 260],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { ok: true, delivered_at: new Date().toISOString(), alert_type: $('Format Discord Alert Message').item.json.alert_type, pr: $('Format Discord Alert Message').item.json.pr_number } }}"
+      }
+    }
+  ],
+  "connections": {
+    "Receive Escalation Payload": {
+      "main": [
+        [
+          { "node": "Format Discord Alert Message", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Format Discord Alert Message": {
+      "main": [
+        [
+          { "node": "POST Alert to Discord Alerts Channel", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "POST Alert to Discord Alerts Channel": {
+      "main": [
+        [
+          { "node": "Respond 200 OK", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  }
+}

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 readonly C_RESET=$'\033[0m'
 readonly C_BOLD=$'\033[1m'
+# shellcheck disable=SC2034  # reserved for future error-output styling (parität zu install.sh)
 readonly C_RED=$'\033[31m'
 readonly C_GREEN=$'\033[32m'
 readonly C_YELLOW=$'\033[33m'

--- a/tests/test_provision_channels.py
+++ b/tests/test_provision_channels.py
@@ -1,0 +1,407 @@
+"""
+Tests für provision-channels.py (Discord Channel Provisioning).
+
+TDD — Red Phase: Tests vor der Implementierung.
+Pattern: Arrange-Act-Assert (AAA).
+Mocking: unittest.mock für requests-Calls.
+"""
+
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, call, patch
+
+# Ensure the discord-bot dir is on the path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "ops", "discord-bot"))
+
+import provision_channels
+from provision_channels import (
+    DiscordClient,
+    channel_name_for_project,
+    provision_guild,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen
+# ---------------------------------------------------------------------------
+
+def make_channel(name: str, channel_id: str = "99") -> dict:
+    """Erstellt ein minimales Discord-Channel-Dict (wie von der API zurückgegeben)."""
+    return {"id": channel_id, "name": name, "type": 0}
+
+
+def make_category(name: str, category_id: str = "10") -> dict:
+    """Erstellt ein minimales Discord-Category-Dict."""
+    return {"id": category_id, "name": name, "type": 4}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: channel_name_for_project — Name-Ableitung
+# ---------------------------------------------------------------------------
+
+class TestChannelNameForProject(unittest.TestCase):
+    """Prüft die reine Namens-Ableitung (keine API-Calls)."""
+
+    def test_project_channel_names_correct(self):
+        """
+        Arrange: Projektname 'ai-portal'
+        Act: channel_name_for_project('ai-portal')
+        Assert: gibt (review_name, shadow_name) Tupel korrekt zurück
+        """
+        # Arrange
+        project = "ai-portal"
+
+        # Act
+        review_name, shadow_name = channel_name_for_project(project)
+
+        # Assert
+        self.assertEqual(review_name, "ai-review-ai-portal")
+        self.assertEqual(shadow_name, "ai-review-shadow-ai-portal")
+
+    def test_global_alerts_channel_name(self):
+        """
+        Arrange: Konstante ALERTS_CHANNEL_NAME
+        Act: importieren
+        Assert: exakter Name 'ai-review-alerts-global'
+        """
+        self.assertEqual(provision_channels.ALERTS_CHANNEL_NAME, "ai-review-alerts-global")
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Happy Path — neue Channels werden erstellt
+# ---------------------------------------------------------------------------
+
+class TestProvisionGuildHappyPath(unittest.TestCase):
+    """Neuer Guild, keine Channels vorhanden → alle werden erstellt."""
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_creates_channels_for_two_projects(self, mock_post, mock_get):
+        """
+        Arrange: GET /guilds/{id}/channels gibt leere Liste zurück.
+        Act: provision_guild mit 2 Projekten aufrufen.
+        Assert: POST wird für jeden Channel + 1 Category + 1 Alerts-Channel aufgerufen.
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: [],
+            raise_for_status=lambda: None,
+        )
+        created_ids = iter(["10", "20", "30", "40", "50", "60"])
+        def post_side_effect(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 201
+            name = kwargs.get("json", {}).get("name", "unknown")
+            resp.json = lambda: {"id": next(created_ids), "name": name}
+            resp.raise_for_status = lambda: None
+            return resp
+        mock_post.side_effect = post_side_effect
+
+        client = DiscordClient(token="fake-token")
+        guild_id = "123"
+        projects = ["ai-portal", "nathan-cockpit"]
+
+        # Act
+        result = provision_guild(client, guild_id, projects, dry_run=False)
+
+        # Assert
+        # 1 Category + 2 Projekte x 2 Channels + 1 Alerts-Global = 6 POST-Calls
+        self.assertEqual(mock_post.call_count, 6)
+        # result enthält summary mit created + skipped
+        self.assertEqual(result["created"], 6)
+        self.assertEqual(result["skipped"], 0)
+        self.assertEqual(result["failed"], 0)
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_creates_alerts_global_exactly_once(self, mock_post, mock_get):
+        """
+        Arrange: Leerer Guild, ein Projekt.
+        Act: provision_guild.
+        Assert: 'ai-review-alerts-global' Channel wird genau einmal erstellt.
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: [], raise_for_status=lambda: None,
+        )
+        created_calls = []
+        def post_side_effect(url, **kwargs):
+            name = kwargs.get("json", {}).get("name", "?")
+            created_calls.append(name)
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.json = lambda: {"id": "11", "name": name}
+            resp.raise_for_status = lambda: None
+            return resp
+        mock_post.side_effect = post_side_effect
+
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        provision_guild(client, "123", ["ai-portal"], dry_run=False)
+
+        # Assert
+        alerts_creates = [n for n in created_calls if n == "ai-review-alerts-global"]
+        self.assertEqual(len(alerts_creates), 1)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Already-Exists-Skip — kein Duplikat
+# ---------------------------------------------------------------------------
+
+class TestProvisionGuildAlreadyExists(unittest.TestCase):
+    """Channels existieren bereits → kein POST, skipped zählt korrekt."""
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_skips_existing_channels(self, mock_post, mock_get):
+        """
+        Arrange: GET liefert alle Channels + Category bereits vorhanden.
+        Act: provision_guild
+        Assert: POST wird NICHT aufgerufen; result['skipped'] == 3
+        """
+        # Arrange — Category + 2 Channels bereits da, kein Alerts-Channel
+        existing = [
+            make_category("AI Review", "10"),
+            make_channel("ai-review-ai-portal", "20"),
+            make_channel("ai-review-shadow-ai-portal", "30"),
+        ]
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: existing, raise_for_status=lambda: None,
+        )
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        result = provision_guild(client, "123", ["ai-portal"], dry_run=False)
+
+        # Assert: 3 existing skipped, 1 alerts-global created (POST once)
+        self.assertEqual(mock_post.call_count, 1)  # nur alerts-global
+        self.assertEqual(result["skipped"], 3)
+        self.assertEqual(result["created"], 1)
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_idempotent_full_existing_guild(self, mock_post, mock_get):
+        """
+        Arrange: Alle Channels + Alerts + Category bereits vorhanden.
+        Act: provision_guild
+        Assert: KEIN POST-Call, skipped = Category + 2 Channels + Alerts = 4
+        """
+        # Arrange
+        existing = [
+            make_category("AI Review", "10"),
+            make_channel("ai-review-ai-portal", "20"),
+            make_channel("ai-review-shadow-ai-portal", "30"),
+            make_channel("ai-review-alerts-global", "40"),
+        ]
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: existing, raise_for_status=lambda: None,
+        )
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        result = provision_guild(client, "123", ["ai-portal"], dry_run=False)
+
+        # Assert
+        self.assertEqual(mock_post.call_count, 0)
+        self.assertEqual(result["skipped"], 4)
+        self.assertEqual(result["failed"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Fail-Continue — ein Channel-Create schlägt fehl, weiter mit nächstem
+# ---------------------------------------------------------------------------
+
+class TestProvisionGuildFailContinue(unittest.TestCase):
+    """Wenn ein Channel-Create fehlschlägt → Log + weiter, kein früher Abbruch."""
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_continues_after_failed_channel_create(self, mock_post, mock_get):
+        """
+        Arrange: Zweiter POST-Call wirft Exception.
+        Act: provision_guild mit 2 Projekten.
+        Assert: Drittes POST wird noch aufgerufen; result['failed'] == 1.
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: [], raise_for_status=lambda: None,
+        )
+        call_count = {"n": 0}
+        def post_side_effect(url, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                # zweiter Call schlägt fehl
+                raise Exception("Discord API Error: 50013 Missing Permissions")
+            name = kwargs.get("json", {}).get("name", "?")
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.json = lambda: {"id": str(call_count["n"]), "name": name}
+            resp.raise_for_status = lambda: None
+            return resp
+        mock_post.side_effect = post_side_effect
+
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        result = provision_guild(client, "123", ["ai-portal", "nathan-cockpit"], dry_run=False)
+
+        # Assert: mehr als 2 Calls → es hat weitergemacht
+        self.assertGreater(mock_post.call_count, 2)
+        self.assertEqual(result["failed"], 1)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Category-Create — Category wird angelegt wenn nicht vorhanden
+# ---------------------------------------------------------------------------
+
+class TestCategoryCreate(unittest.TestCase):
+    """Wenn Category 'AI Review' nicht existiert → wird zuerst angelegt."""
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_category_created_first(self, mock_post, mock_get):
+        """
+        Arrange: Leerer Guild.
+        Act: provision_guild.
+        Assert: Erster POST-Call ist ein Category-Create (type=4).
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: [], raise_for_status=lambda: None,
+        )
+        post_calls_bodies = []
+        def post_side_effect(url, **kwargs):
+            post_calls_bodies.append(kwargs.get("json", {}))
+            resp = MagicMock()
+            resp.status_code = 201
+            name = kwargs.get("json", {}).get("name", "?")
+            resp.json = lambda: {"id": str(len(post_calls_bodies)), "name": name}
+            resp.raise_for_status = lambda: None
+            return resp
+        mock_post.side_effect = post_side_effect
+
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        provision_guild(client, "123", ["ai-portal"], dry_run=False)
+
+        # Assert: erstes POST ist type=4 (GUILD_CATEGORY)
+        self.assertGreater(len(post_calls_bodies), 0)
+        first_body = post_calls_bodies[0]
+        self.assertEqual(first_body.get("type"), 4)
+        self.assertEqual(first_body.get("name"), "AI Review")
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Dry-Run — kein API-Call beim --dry-run
+# ---------------------------------------------------------------------------
+
+class TestDryRun(unittest.TestCase):
+    """--dry-run führt KEINE POST-Calls aus, GET zur Prüfung ist erlaubt."""
+
+    @patch("provision_channels.requests.get")
+    @patch("provision_channels.requests.post")
+    def test_dry_run_no_post_calls(self, mock_post, mock_get):
+        """
+        Arrange: Leerer Guild, dry_run=True.
+        Act: provision_guild
+        Assert: POST wird NIE aufgerufen.
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: [], raise_for_status=lambda: None,
+        )
+        client = DiscordClient(token="fake-token")
+
+        # Act
+        result = provision_guild(client, "123", ["ai-portal", "nathan-cockpit"], dry_run=True)
+
+        # Assert
+        mock_post.assert_not_called()
+        # dry_run meldet would_create statt created
+        self.assertIn("would_create", result)
+        self.assertGreater(result["would_create"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: DiscordClient — Token wird korrekt als Authorization-Header gesetzt
+# ---------------------------------------------------------------------------
+
+class TestDiscordClientHeaders(unittest.TestCase):
+    """DiscordClient setzt Authorization + Content-Type Header korrekt."""
+
+    @patch("provision_channels.requests.get")
+    def test_authorization_header_set(self, mock_get):
+        """
+        Arrange: DiscordClient mit Token 'test-token-xyz'.
+        Act: list_guild_channels aufrufen.
+        Assert: Authorization-Header enthält 'Bot test-token-xyz'.
+        """
+        # Arrange
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: [], raise_for_status=lambda: None,
+        )
+        client = DiscordClient(token="test-token-xyz")
+
+        # Act
+        client.list_guild_channels("123")
+
+        # Assert
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {}) if call_kwargs[1] else call_kwargs[0][1] if len(call_kwargs[0]) > 1 else {}
+        # Flexibel: Header können als positional oder keyword übergeben sein
+        if not headers:
+            headers = mock_get.call_args.kwargs.get("headers", {})
+        self.assertIn("Authorization", headers)
+        self.assertEqual(headers["Authorization"], "Bot test-token-xyz")
+
+
+# ---------------------------------------------------------------------------
+# Test 8: DISCORD_BOT_TOKEN aus Environment lesen
+# ---------------------------------------------------------------------------
+
+class TestEnvironmentToken(unittest.TestCase):
+    """DISCORD_BOT_TOKEN wird aus env gelesen, wenn nicht explizit übergeben."""
+
+    def test_missing_token_raises(self):
+        """
+        Arrange: DISCORD_BOT_TOKEN nicht gesetzt.
+        Act: DiscordClient() ohne token-Argument.
+        Assert: EnvironmentError oder ValueError wird geraised.
+        """
+        # Arrange
+        env_backup = os.environ.pop("DISCORD_BOT_TOKEN", None)
+
+        try:
+            # Act + Assert
+            with self.assertRaises((EnvironmentError, ValueError, KeyError)):
+                DiscordClient()
+        finally:
+            if env_backup is not None:
+                os.environ["DISCORD_BOT_TOKEN"] = env_backup
+
+    def test_token_from_env(self):
+        """
+        Arrange: DISCORD_BOT_TOKEN in env gesetzt.
+        Act: DiscordClient() ohne explizites token.
+        Assert: DiscordClient wird erstellt, token ist gesetzt.
+        """
+        # Arrange
+        os.environ["DISCORD_BOT_TOKEN"] = "env-token-abc"
+        try:
+            # Act
+            client = DiscordClient()
+
+            # Assert
+            self.assertEqual(client.token, "env-token-abc")
+        finally:
+            del os.environ["DISCORD_BOT_TOKEN"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Discord IaC Bundle — ready-to-deploy (Phase 5 Discord activation)

Baut die komplette Discord-Infrastructure-as-Code für den geplanten End-of-Plan Cutover. Alles ist fertig, wartet auf Nicos manuellen Discord-Dev-Portal-Schritt (siehe `ops/discord-bot/register-bot.md`).

## Contents (12 Files, 4 commits)

| Area | Files |
|---|---|
| **Channel-Provisioning** | `ops/discord-bot/provision_channels.py` (319 LOC) + tests (407 LOC, 12 tests TDD AAA) |
| **One-Time-Setup Docs** | `ops/discord-bot/register-bot.md` (160 LOC, Dev-Portal Runbook) |
| **One-Shot Setup** | `ops/discord-bot/setup.sh` (219 LOC, orchestriert provisioning + n8n + Tailscale) |
| **ops-n8n Stack** | `ops/n8n/docker-compose.yml` (Port 5679, shared env, healthcheck), `setup-ops-n8n.sh`, `backup-ops-n8n.sh` |
| **n8n Workflows** | `ai-review-dispatcher.json` (Components v2 buttons), `ai-review-callback.json` (Ed25519-verify + GitHub API), `ai-review-escalation.json` (@here alerts) |
| **Docs** | `ops/README.md` + `.env.example` |

## Automated per setup.sh

- [x] Channel-Provisioning (idempotent, pro Projekt `#ai-review-<project>` + shadow-variant)
- [x] Category-Anlage ("AI Review")
- [x] ops-n8n Container-Start + Health-Wait
- [x] Workflow-Import via n8n REST API
- [x] Tailscale Funnel Konfiguration

## Manual User-Actions (one-time, dokumentiert)

1. Discord Dev Portal: Application "Nathan Ops Bot" + Token/Public-Key kopieren
2. Bot zum "Nathan Ops" Guild via OAuth2-URL einladen
3. Guild-ID in `~/.openclaw/.env`
4. `bash ops/discord-bot/setup.sh` (sudo für Tailscale)
5. n8n UI: API-Key generieren, dann `setup-ops-n8n.sh --import-only`
6. Dev Portal: Interactions Endpoint URL eintragen

## Assumptions (Nico-validation needed)

- Tailscale-Hostname wird dynamisch via `tailscale status --json` ermittelt
- n8n API-Key muss nach erstem Container-Start manuell generiert werden (Script erkennt das + gibt klare Anweisung)
- Discord API v10 Components-v2 Flags korrekt (2026-04 Stand)
- Ed25519-Verify via WebCrypto (n8n>=1.x Voraussetzung)

## Test Plan

- [x] `provision_channels.py` — 12 Tests grün
- [ ] Manueller Smoke: Dev-Portal-Setup → `setup.sh` → verify Channels in Discord
- [ ] End-to-End: erste PR-Review postet in `#ai-review-shadow-<project>`

## Ready to merge when

- User hat Dev Portal Setup gemacht + Token in `.env`
- Manueller End-to-End-Smoke erfolgreich

## NOT in this PR

- Bestehende ai-portal-n8n bleibt unberührt (Plan §287 — Business-Concerns bleiben dort)
- Telegram-Workflows werden in Phase 5 separat archiviert/gelöscht

🤖 Generated with [Claude Code](https://claude.com/claude-code)
