### PR TITLE
docs(ops): consolidate default setup on ai-portal-n8n (:5678)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,7 +1,20 @@
-# ops — Discord Bot + ops-n8n + Tailscale Funnel
+# ops — Discord Bot + n8n Bridge + Tailscale Funnel
 
 Dieser Ordner enthält die vollständige Infrastructure-as-Code für den **Nathan Ops Discord Bot**:
 der Messaging-Bus für die AI-Review-Pipeline.
+
+> **Aktueller Deployment-Modus: CONSOLIDATED (seit 2026-04-20)**
+>
+> Die AI-Review-Workflows leben in der **bestehenden `ai-portal-n8n`** (Port 5678),
+> nicht in einem separaten ops-n8n-Container. Rationale:
+>
+> - r2d2 ist small home-server — doppelte n8n-Instanzen = unnötige Ops-Kosten
+> - 2-User-Family-Setup: Blast-Radius-Argumente weniger kritisch als Einfachheit
+> - n8n Tags/Folders reichen für Soft-Separation innerhalb einer Instanz
+> - Wörkflows in ai-portal-n8n bereits importiert + aktiviert
+>
+> Die `n8n/docker-compose.yml` bleibt als **optionaler Fallback** dokumentiert, falls
+> eine saubere Container-Trennung später doch nötig wird.
 
 ---
 
@@ -26,9 +39,13 @@ ops/
         └── backup-ops-n8n.sh   Wöchentliches Backup (cron-kompatibel)
 ```
 
-**Trennung von ai-portal-n8n:**
-- `ai-portal-n8n` (Port 5678): Business-Workflows (Finance, Research, Email). Bleibt unverändert.
-- `ops-n8n` (Port 5679): Ausschließlich AI-Review Messaging-Bridge. Teil von `agent-stack`.
+**Aktueller Setup (CONSOLIDATED):**
+- `ai-portal-n8n` (Port 5678): Business-Workflows (Finance, Research, Email) **+ AI-Review-Bridge**
+- AI-Review-Workflows tragen `[AI-Review]` Prefix im Namen — Soft-Separation via n8n-Tags
+
+**Optionaler Alt-Setup (Plan-Original, §290-307):**
+- `ops-n8n` (Port 5679): Separater Container via `n8n/docker-compose.yml`
+- Nur aktivieren wenn Blast-Radius-Trennung wichtiger als Ops-Einfachheit wird
 
 ---
 

--- a/ops/discord-bot/setup.sh
+++ b/ops/discord-bot/setup.sh
@@ -145,7 +145,7 @@ log_ok "ops-n8n Container gestartet."
 
 log_info "=== Schritt 4: Warten auf ops-n8n Health ==="
 
-N8N_HEALTH_URL="http://127.0.0.1:5679/healthz"
+N8N_HEALTH_URL="http://127.0.0.1:5678/healthz"
 MAX_WAIT=60
 WAITED=0
 INTERVAL=3
@@ -182,8 +182,8 @@ log_ok "Workflows importiert."
 
 log_info "=== Schritt 6: Tailscale Funnel konfigurieren ==="
 
-log_info "Aktiviere Tailscale Funnel für /webhook/discord-interaction → localhost:5679 ..."
-sudo tailscale funnel --bg --set-path /webhook/discord-interaction localhost:5679
+log_info "Aktiviere Tailscale Funnel für /webhook/discord-interaction → localhost:5678 ..."
+sudo tailscale funnel --bg --set-path /webhook/discord-interaction localhost:5678
 log_ok "Tailscale Funnel aktiv."
 
 # Tailscale-Hostname ermitteln
@@ -211,8 +211,8 @@ echo "  Discord verifiziert den Endpoint sofort."
 echo ""
 echo "------------------------------------------------------------"
 echo "Kanäle erstellt für Projekte: $PROJECTS"
-echo "ops-n8n läuft auf:            http://127.0.0.1:5679"
-echo "n8n UI erreichbar via:        http://127.0.0.1:5679 (lokal)"
+echo "ops-n8n läuft auf:            http://127.0.0.1:5678"
+echo "n8n UI erreichbar via:        http://127.0.0.1:5678 (lokal)"
 echo "Tailscale Funnel URL:         $INTERACTIONS_URL"
 echo "------------------------------------------------------------"
 echo ""

--- a/ops/n8n/scripts/backup-ops-n8n.sh
+++ b/ops/n8n/scripts/backup-ops-n8n.sh
@@ -11,7 +11,7 @@
 #
 # Benötigt:
 #   - N8N_API_KEY in ~/.openclaw/.env
-#   - ops-n8n Container läuft (http://127.0.0.1:5679 erreichbar)
+#   - ops-n8n Container läuft (http://127.0.0.1:5678 erreichbar)
 
 set -euo pipefail
 
@@ -33,7 +33,7 @@ ENV_FILE="$HOME/.openclaw/.env"
 [[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
 
 N8N_API_KEY="${N8N_API_KEY:-}"
-N8N_API_BASE="http://127.0.0.1:5679/api/v1"
+N8N_API_BASE="http://127.0.0.1:5678/api/v1"
 BACKUP_BASE="$HOME/.openclaw/backups/ops-n8n"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 BACKUP_DIR="$BACKUP_BASE/$TIMESTAMP"
@@ -41,8 +41,8 @@ BACKUP_DIR="$BACKUP_BASE/$TIMESTAMP"
 mkdir -p "$BACKUP_DIR"
 
 # Erreichbarkeit prüfen
-if ! curl -sf "http://127.0.0.1:5679/healthz" &>/dev/null; then
-    die "ops-n8n nicht erreichbar (http://127.0.0.1:5679/healthz). Container läuft?"
+if ! curl -sf "http://127.0.0.1:5678/healthz" &>/dev/null; then
+    die "ops-n8n nicht erreichbar (http://127.0.0.1:5678/healthz). Container läuft?"
 fi
 
 if [[ -z "$N8N_API_KEY" ]]; then

--- a/ops/n8n/scripts/setup-ops-n8n.sh
+++ b/ops/n8n/scripts/setup-ops-n8n.sh
@@ -47,10 +47,10 @@ if [[ "$IMPORT_ONLY" == "false" ]]; then
     log_ok "Container gestartet."
 
     # Auf Health warten
-    log_info "Warte auf ops-n8n Health (http://127.0.0.1:5679/healthz) ..."
+    log_info "Warte auf ops-n8n Health (http://127.0.0.1:5678/healthz) ..."
     MAX_WAIT=90
     WAITED=0
-    until curl -sf "http://127.0.0.1:5679/healthz" &>/dev/null; do
+    until curl -sf "http://127.0.0.1:5678/healthz" &>/dev/null; do
         [[ $WAITED -ge $MAX_WAIT ]] && die "ops-n8n nicht healthy nach ${MAX_WAIT}s. docker logs ops-n8n"
         echo -n "."
         sleep 3
@@ -61,7 +61,7 @@ if [[ "$IMPORT_ONLY" == "false" ]]; then
 fi
 
 # --- Schritt 2: Workflows importieren via n8n REST API ---
-N8N_API_BASE="http://127.0.0.1:5679/api/v1"
+N8N_API_BASE="http://127.0.0.1:5678/api/v1"
 N8N_API_KEY="${N8N_API_KEY:-}"
 
 if [[ -z "$N8N_API_KEY" ]]; then


### PR DESCRIPTION
## Rationale

Session-Discovery 2026-04-20: r2d2 hat bereits zwei n8n-Instanzen (docker + native-etrox). Plan §290-307 wollte dritte separat, aber r2d2-Ressourcenprofil (4 GB Swap voll, 4 Cores, 15 GB RAM bei 10 GB used) empfiehlt Konsolidierung.

## Changes

- `ops/README.md`: neuer "CONSOLIDATED" Banner + Rationale; docker-compose.yml als optionaler Fallback markiert
- `ops/discord-bot/setup.sh`: Tailscale-Funnel + health-check auf :5678
- `ops/n8n/scripts/{setup,backup}-ops-n8n.sh`: Port 5679 → 5678
- docker-compose.yml + separate-setup-scripts bleiben für optionale spätere Separation

## Live-State

3 Workflows bereits in ai-portal-n8n importiert + aktiviert (r2d2, 2026-04-20). Webhook smoke HTTP 200.

## Companion-PR

[ai-review-pipeline#6](https://github.com/EtroxTaran/ai-review-pipeline/pull/6) — discord_notify.py default URL change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)