### PR TITLE
feat(ops): AI-Workflows secrets domain-separation

### DIFF
--- a/ops/compose/n8n-ai-review.override.yml
+++ b/ops/compose/n8n-ai-review.override.yml
@@ -1,0 +1,31 @@
+# n8n-ai-review.override.yml
+#
+# Docker-Compose-Override für ai-portal-n8n, ergänzt den Container um einen
+# ZWEITEN env_file-Mount für AI-Review-Pipeline-Secrets.
+#
+# Design-Rationale:
+#   - ~/.openclaw/.env = OpenClaw-Agent-Domain (bestehend, separat)
+#   - ~/.config/ai-workflows/env = AI-Workflows-Domain (neu, unsere Secrets)
+#   - Consolidation auf ai-portal-n8n (Port 5678) per Plan A+
+#
+# Enthaltene Vars (aus ~/.config/ai-workflows/env):
+#   - DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, DISCORD_APPLICATION_ID, DISCORD_GUILD_ID
+#   - DISCORD_ALERTS_CHANNEL_ID + DISCORD_CHANNEL_* (pro Projekt)
+#   - GITHUB_TOKEN, GITHUB_REPO (für ai-review-callback Workflow)
+#
+# Usage:
+#   docker compose \
+#     -f ~/projects/ai-portal/docker-compose.yml \
+#     -f ~/projects/agent-stack/ops/compose/n8n-ai-review.override.yml \
+#     up -d --force-recreate n8n-portal
+#
+# ODER via Helper-Script:
+#   ~/projects/agent-stack/ops/scripts/restart-n8n-with-ai-review.sh
+
+services:
+  n8n-portal:
+    env_file:
+      # OpenClaw-Secrets (bestehend, unverändert)
+      - /home/clawd/.openclaw/.env
+      # AI-Workflows-Secrets (neu, separate Domain)
+      - /home/clawd/.config/ai-workflows/env

--- a/ops/discord-bot/ENV-SOT.md
+++ b/ops/discord-bot/ENV-SOT.md
@@ -1,0 +1,69 @@
+# AI-Workflows Secrets Source-of-Truth
+
+**Location:** `~/.config/ai-workflows/env` (chmod 600)
+
+Alle Secrets für AI-Workflow-Systeme (ai-review-pipeline + ai-portal-Workflows die mit
+AI-Review interagieren) leben hier. **Separat von `~/.openclaw/.env`** (OpenClaw-Agent-Domain).
+
+## Warum getrennt?
+
+- **OpenClaw-Agent** ist ein eigenständiges Assistant-System (Nathan, Fleet, Sub-Workspaces)
+- **AI-Workflows** sind Coding/Review-Infrastructure
+- Cross-Domain-Secrets-Sharing = unsauber (OpenClaw-Rotation beeinflusst AI-Review-Uptime
+  und umgekehrt, Blast-Radius größer, Audit-Trail verschwimmt)
+
+Plan-Original (§207-212) hatte `~/.openclaw/.env` als globale Secrets-SoT definiert —
+das war Design-Fehler. Diese Separation korrigiert das.
+
+## Template
+
+```bash
+# AI-Workflows Secrets-SoT (ai-review-pipeline + ai-portal Workflows)
+# NICHT mit ~/.openclaw/.env mischen — separate Domain.
+
+# Discord (Nathan-Ops-Guild — AI-Review-Bridge)
+DISCORD_BOT_TOKEN=<bot-token>
+DISCORD_GUILD_ID=<guild-id>
+DISCORD_APPLICATION_ID=<app-id>
+DISCORD_PUBLIC_KEY=<ed25519-public-key>
+
+# Discord Channel-IDs (aus provision_channels.py Live-Setup)
+DISCORD_ALERTS_CHANNEL_ID=<alerts-channel-id>
+DISCORD_CHANNEL_AI_PORTAL=<channel-id>
+DISCORD_CHANNEL_AI_PORTAL_SHADOW=<channel-id>
+# ... weitere pro Projekt
+
+# GitHub (für n8n-Callback-Workflow → PR-Comments schreiben)
+GITHUB_REPO=<owner/repo-default>
+GITHUB_TOKEN=<pat-with-repo-workflow-scope>
+```
+
+## Zugriff vom n8n-Container
+
+Via docker-compose override (Plan §290 — nicht invasiv):
+- `ops/compose/n8n-ai-review.override.yml` fügt einen ZWEITEN `env_file` Mount hinzu
+- Startet mit: `ops/scripts/restart-n8n-with-ai-review.sh` (wrapper um `docker compose`)
+
+Die bestehende `ai-portal/docker-compose.yml` bleibt unverändert — `~/.openclaw/.env` wird
+weiter für bestehende Business-Workflow-Credentials genutzt. Unsere neue Datei wird ERGÄNZEND
+gelesen.
+
+## Permission
+
+```bash
+chmod 600 ~/.config/ai-workflows/env
+```
+
+Das Restart-Script warnt bei falschen Perms.
+
+## Rotation
+
+Bot-Token:
+1. Discord Dev Portal → Bot → Reset Token
+2. Neuen Token in `~/.config/ai-workflows/env` eintragen
+3. `./ops/scripts/restart-n8n-with-ai-review.sh` ausführen
+
+GitHub-Token:
+1. GitHub Settings → Developer settings → PAT rotieren
+2. Neuen Token in `~/.config/ai-workflows/env` eintragen
+3. Container restart wie oben

--- a/ops/scripts/restart-n8n-with-ai-review.sh
+++ b/ops/scripts/restart-n8n-with-ai-review.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# restart-n8n-with-ai-review.sh
+#
+# Startet/Recreated ai-portal-n8n Container mit dem AI-Review-Override,
+# damit die Discord-Secrets aus ~/.config/ai-workflows/env verfügbar werden.
+#
+# Der bestehende ai-portal-n8n-portal-1 Container wird mit --force-recreate
+# neu erstellt (nötig weil env_file nur bei create gelesen wird).
+
+set -euo pipefail
+
+readonly AI_PORTAL_COMPOSE="${AI_PORTAL_COMPOSE:-${HOME}/projects/ai-portal/docker-compose.yml}"
+readonly AI_REVIEW_OVERRIDE="${AI_REVIEW_OVERRIDE:-${HOME}/projects/agent-stack/ops/compose/n8n-ai-review.override.yml}"
+readonly AI_WORKFLOWS_ENV="${AI_WORKFLOWS_ENV:-${HOME}/.config/ai-workflows/env}"
+
+die() { printf 'restart-n8n: %s\n' "$*" >&2; exit 1; }
+
+[[ -f "$AI_PORTAL_COMPOSE" ]]   || die "ai-portal docker-compose nicht gefunden: $AI_PORTAL_COMPOSE"
+[[ -f "$AI_REVIEW_OVERRIDE" ]]  || die "override fehlt: $AI_REVIEW_OVERRIDE"
+[[ -f "$AI_WORKFLOWS_ENV" ]]    || die "env-file fehlt: $AI_WORKFLOWS_ENV (chmod 600 + DISCORD_BOT_TOKEN nötig)"
+
+# chmod-Check: env-file muss 600 sein (Leak-Prevention)
+env_mode="$(stat -c %a "$AI_WORKFLOWS_ENV" 2>/dev/null || stat -f %A "$AI_WORKFLOWS_ENV")"
+if [[ "$env_mode" != "600" ]]; then
+    printf 'WARN: %s hat mode %s, empfohlen 600\n' "$AI_WORKFLOWS_ENV" "$env_mode" >&2
+fi
+
+echo ">>> Recreating n8n-portal mit AI-Review-Override ..."
+docker compose \
+    -f "$AI_PORTAL_COMPOSE" \
+    -f "$AI_REVIEW_OVERRIDE" \
+    up -d --force-recreate n8n-portal
+
+echo ""
+echo ">>> Warte auf Container-Start ..."
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if curl -sf http://127.0.0.1:5678/healthz >/dev/null 2>&1; then
+        echo "healthz OK"
+        break
+    fi
+    sleep 2
+done
+
+echo ""
+echo ">>> Env-Verify (DISCORD_BOT_TOKEN present?):"
+if docker exec ai-portal-n8n-portal-1 printenv DISCORD_BOT_TOKEN >/dev/null 2>&1; then
+    echo "  ✅ DISCORD_BOT_TOKEN im Container sichtbar"
+else
+    die "DISCORD_BOT_TOKEN nicht im Container — env_file mount prüfen"
+fi
+
+echo ""
+echo ">>> AI-Review Workflows aktiv?"
+docker exec ai-portal-n8n-portal-1 n8n list:workflow 2>/dev/null | grep -E "AI-Review" || echo "WARN: keine AI-Review-Workflows gefunden"
+
+echo ""
+echo ">>> DONE. n8n-portal recreated. Webhook-Endpoints:"
+echo "   POST http://127.0.0.1:5678/webhook/ai-review-dispatch"
+echo "   POST http://127.0.0.1:5678/webhook/discord-interaction"
+echo "   POST http://127.0.0.1:5678/webhook/ai-review-escalation"


### PR DESCRIPTION
## Problem

Plan-Original §207-212 definierte `~/.openclaw/.env` als globale Secrets-SoT für ALLE Tokens. Das ist Design-Fehler weil:
- **OpenClaw** = eigenes Assistant-Agent-System (Nathan, Fleet, Sub-Workspaces per `~/.openclaw/workspace/AGENTS.md`)
- **AI-Workflows** = Coding/Review-Infrastructure (ai-review-pipeline + ai-portal)

Cross-Domain-Secrets = unsauber (Rotation-Blast-Radius, Audit-Trail verschwimmt, Bot-Token-Namespace kollidiert).

## Solution

- **Neuer Secrets-SoT**: `~/.config/ai-workflows/env` (chmod 600, lokal, nicht committed)
- **Compose-Override**: `ops/compose/n8n-ai-review.override.yml` — fügt ZWEITEN `env_file` zum n8n-Container hinzu, OHNE `ai-portal/docker-compose.yml` zu editieren
- **Wrapper-Script**: `ops/scripts/restart-n8n-with-ai-review.sh` — startet Container mit beiden Compose-Files + Preflight + Smoke-Test

**OpenClaw bleibt komplett unberührt.** ai-portal-Business-Workflow-Secrets lesen weiter `~/.openclaw/.env`, Discord/AI-Review-Secrets kommen aus der neuen Datei.

## Live-Verified

Deployed auf r2d2 (2026-04-20):
- Container recreated mit override → DISCORD_BOT_TOKEN im Container sichtbar ✅
- E2E-Smoke: `POST /webhook/ai-review-dispatch` → Discord-Message in `#ai-review-ai-review-pipeline` mit 3 Buttons ✅
- Begleitender Fix: [agent-stack#fix/dispatcher-components-v2-flag](https://github.com/EtroxTaran/agent-stack/pull/3) (`flags:32768`-Incompat mit `content`-Feld)

## Test Plan

- [x] shellcheck -x auf restart-script: pass
- [x] YAML-syntax override: pass
- [x] Live: DISCORD_BOT_TOKEN in container printenv sichtbar
- [x] Live: E2E webhook → Discord-Message sichtbar
- [ ] Nach merge: docs/messaging-bridge.md referenziert neuen SoT statt openclaw/.env (separater docs-PR)
- [ ] ops/* Scripts (provision_channels.py, init-server.sh, setup.sh) auf neuen env-Pfad migrieren (separater PR)

## No breaking change

Alles additive. Der bestehende ai-portal-Container behält Zugriff auf ~/.openclaw/.env für Business-Concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)