### PR TITLE
chore(ops): migrate AI-Review scripts to ~/.config/ai-workflows/env

### DIFF
--- a/ops/discord-bot/init-server.sh
+++ b/ops/discord-bot/init-server.sh
@@ -10,20 +10,21 @@
 # Entweder DISCORD_PROJECTS env-var überschreiben, oder provision_channels.py
 # direkt mit eigenen --projects aufrufen.
 #
-# Required env:
-#   DISCORD_BOT_TOKEN  — Bot-Token aus Discord Dev Portal (in ~/.openclaw/.env)
-#   DISCORD_GUILD_ID   — Server-ID aus Discord Dev-Mode (in ~/.openclaw/.env)
+# Required env (Secrets-SoT: ~/.config/ai-workflows/env, chmod 600):
+#   DISCORD_BOT_TOKEN  — Bot-Token aus Discord Dev Portal
+#   DISCORD_GUILD_ID   — Server-ID aus Discord Dev-Mode
 #
 # Optional:
-#   DISCORD_PROJECTS   — CSV-Liste (Default: siehe PROJECTS_DEFAULT unten)
-#   DRY_RUN            — "1" für Preview ohne API-Writes
+#   DISCORD_PROJECTS    — CSV-Liste (Default: siehe PROJECTS_DEFAULT unten)
+#   DRY_RUN             — "1" für Preview ohne API-Writes
+#   AI_WORKFLOWS_ENV    — Pfad-Override (Default: ~/.config/ai-workflows/env)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 readonly PROVISION_PY="${SCRIPT_DIR}/provision_channels.py"
-readonly ENV_FILE="${HOME}/.openclaw/.env"
+readonly ENV_FILE="${AI_WORKFLOWS_ENV:-${HOME}/.config/ai-workflows/env}"
 
 readonly PROJECTS_DEFAULT="ai-portal,ai-review-pipeline,agent-stack,nathan-cockpit,openclaw-office,research-workflow-n8n"
 

--- a/ops/discord-bot/provision_channels.py
+++ b/ops/discord-bot/provision_channels.py
@@ -81,7 +81,7 @@ class DiscordClient:
             if not token:
                 raise EnvironmentError(
                     "DISCORD_BOT_TOKEN nicht gesetzt. "
-                    "Bitte in ~/.openclaw/.env oder als env-var exportieren."
+                    "Bitte in ~/.config/ai-workflows/env (chmod 600) oder als env-var exportieren."
                 )
         self.token = token
         self._headers = {

--- a/ops/discord-bot/setup.sh
+++ b/ops/discord-bot/setup.sh
@@ -11,7 +11,8 @@
 #   7. Finale Anweisungen ausgeben
 #
 # Voraussetzung:
-#   - ~/.openclaw/.env enthält DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, N8N_API_KEY
+#   - ~/.config/ai-workflows/env (chmod 600) enthält DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, N8N_API_KEY
+#     (Domain-getrennt von ~/.openclaw/.env; override via AI_WORKFLOWS_ENV)
 #   - tailscale is installed and authenticated on r2d2
 #   - docker + docker compose v2 installed
 
@@ -46,14 +47,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 OPS_DIR="$REPO_ROOT/ops"
 N8N_DIR="$OPS_DIR/n8n"
 BOT_DIR="$OPS_DIR/discord-bot"
-ENV_FILE="$HOME/.openclaw/.env"
+ENV_FILE="${AI_WORKFLOWS_ENV:-$HOME/.config/ai-workflows/env}"
 
 # ---------------------------------------------------------------------------
 # Schritt 0: Env-Datei laden
 # ---------------------------------------------------------------------------
 
 if [[ ! -f "$ENV_FILE" ]]; then
-    die "~/.openclaw/.env nicht gefunden. Bitte anlegen (siehe register-bot.md)."
+    die "env-file nicht gefunden: $ENV_FILE (chmod 600 anlegen — siehe ops/discord-bot/ENV-SOT.md)"
 fi
 
 # shellcheck source=/dev/null

--- a/ops/n8n/README.md
+++ b/ops/n8n/README.md
@@ -1,19 +1,26 @@
-# ops-n8n
+# ops-n8n — Optionaler separater n8n-Container
 
-Messaging-Bridge für die AI-Review-Pipeline. Getrennt von ai-portal-n8n,
-damit Maintenance unabhängig läuft.
+**Aktuelles Deployment**: AI-Review läuft konsolidiert in der bestehenden
+`ai-portal-n8n` (Port 5678) — siehe [../README.md](../README.md) "CONSOLIDATED" Banner
+und [../scripts/restart-n8n-with-ai-review.sh](../scripts/restart-n8n-with-ai-review.sh).
+
+Dieses Verzeichnis bleibt als **Fallback** für den Fall dass Container-Trennung
+später nötig wird (Blast-Radius, Rate-Limit-Isolation, Upgrade-Unabhängigkeit).
+
+## Bei Aktivierung
 
 - Port 5679 (5678 bleibt ai-portal-n8n für Business-Workflows)
 - Image: `n8nio/n8n:latest` (kein Custom-Build)
-- Env-File: `~/.openclaw/.env`
+- Env-File: `~/.config/ai-workflows/env` (chmod 600, AI-Workflows-Domain —
+  **nicht** `~/.openclaw/.env`; OpenClaw ist eigenständiges Agent-System)
 - Volume: `ops-n8n-data`
 
-Wird in **Phase 3** (Plan) implementiert — aktuell leer.
+## Inhalt
 
-Geplant:
-- `docker-compose.yml`
-- `workflows/ai-review-dispatcher.json` (Discord Components v2, Inline-Buttons)
-- `workflows/ai-review-callback.json` (Discord Interaction → GitHub API)
-- `workflows/ai-review-escalation.json` (Alert → Channel pro Projekt)
-- `scripts/setup-ops-n8n.sh`
-- `scripts/backup-ops-n8n.sh`
+- `docker-compose.yml` (optional-fallback, zweite n8n-Instanz auf Port 5679)
+- `workflows/` — 3 JSON-Files (bereits in ai-portal-n8n importiert + aktiv):
+  - `ai-review-dispatcher.json` (Discord Message + Inline-Buttons)
+  - `ai-review-callback.json` (Discord Interaction → GitHub API, Ed25519 Verify)
+  - `ai-review-escalation.json` (Alert → Channel pro Projekt)
+- `scripts/setup-ops-n8n.sh` — optional: Container starten + Workflows importieren
+- `scripts/backup-ops-n8n.sh` — wöchentliches Backup (cron-kompatibel)

--- a/ops/n8n/docker-compose.yml
+++ b/ops/n8n/docker-compose.yml
@@ -1,10 +1,13 @@
 version: "3.9"
 
-# ops-n8n — Globale Messaging-Bridge für AI-Review-Pipeline
+# ops-n8n — OPTIONALER separater n8n-Container für AI-Review-Messaging-Bridge
+# Aktuelles Deployment nutzt konsolidierte ai-portal-n8n (Plan A+, siehe ops/README.md).
+# Dieses File bleibt als Fallback falls saubere Container-Trennung später nötig wird.
+#
 # Port 5679 (5678 bleibt bei ai-portal-n8n für Business-Workflows)
 # Image: n8nio/n8n:latest (kein Custom-Build)
 # Volume: ops-n8n-data (Credentials + Workflow-Storage)
-# Env-File: ~/.openclaw/.env (geteilte Secrets)
+# Env-File: ~/.config/ai-workflows/env (AI-Workflows-Secrets, getrennt von OpenClaw)
 
 services:
   ops-n8n:
@@ -14,7 +17,7 @@ services:
     ports:
       - "5679:5678"
     env_file:
-      - ${HOME}/.openclaw/.env
+      - ${HOME}/.config/ai-workflows/env
     environment:
       # n8n interne Config
       N8N_HOST: "0.0.0.0"

--- a/ops/n8n/scripts/backup-ops-n8n.sh
+++ b/ops/n8n/scripts/backup-ops-n8n.sh
@@ -7,10 +7,10 @@
 # Exportiert:
 #   - Alle Workflows als JSON (via n8n REST API)
 #   - Credential-IDs als Liste (keine Werte — Security!)
-#   - Paketiert als tarball in ~/.openclaw/backups/ops-n8n/
+#   - Paketiert als tarball in ~/ai-workflows/backups/ops-n8n/ (override via AI_WORKFLOWS_BACKUP_DIR)
 #
 # Benötigt:
-#   - N8N_API_KEY in ~/.openclaw/.env
+#   - N8N_API_KEY in ~/.config/ai-workflows/env (override via AI_WORKFLOWS_ENV)
 #   - ops-n8n Container läuft (http://127.0.0.1:5678 erreichbar)
 
 set -euo pipefail
@@ -28,13 +28,13 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 die()       { log_error "$*"; exit 1; }
 
 # Env laden
-ENV_FILE="$HOME/.openclaw/.env"
+ENV_FILE="${AI_WORKFLOWS_ENV:-$HOME/.config/ai-workflows/env}"
 # shellcheck source=/dev/null
 [[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
 
 N8N_API_KEY="${N8N_API_KEY:-}"
 N8N_API_BASE="http://127.0.0.1:5678/api/v1"
-BACKUP_BASE="$HOME/.openclaw/backups/ops-n8n"
+BACKUP_BASE="${AI_WORKFLOWS_BACKUP_DIR:-$HOME/ai-workflows/backups/ops-n8n}"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 BACKUP_DIR="$BACKUP_BASE/$TIMESTAMP"
 

--- a/ops/n8n/scripts/setup-ops-n8n.sh
+++ b/ops/n8n/scripts/setup-ops-n8n.sh
@@ -7,8 +7,13 @@
 #
 # Benötigt:
 #   - docker + docker compose v2
-#   - N8N_API_KEY in ~/.openclaw/.env (nach erstem Start in n8n UI generieren)
+#   - N8N_API_KEY in ~/.config/ai-workflows/env (chmod 600) — nach erstem
+#     Start in n8n UI generieren. Override via AI_WORKFLOWS_ENV env-var.
 #   - WORKFLOWS_DIR: ops/n8n/workflows/ mit den 3 JSON-Files
+#
+# Hinweis: Dieses Script ist für den OPTIONALEN separaten ops-n8n Container
+# (Plan §290-307). Im aktuellen Deployment läuft AI-Review konsolidiert in
+# der bestehenden ai-portal-n8n (siehe ops/README.md + ops/scripts/restart-n8n-with-ai-review.sh).
 
 set -euo pipefail
 
@@ -28,7 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 N8N_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$N8N_DIR/docker-compose.yml"
 WORKFLOWS_DIR="$N8N_DIR/workflows"
-ENV_FILE="$HOME/.openclaw/.env"
+ENV_FILE="${AI_WORKFLOWS_ENV:-$HOME/.config/ai-workflows/env}"
 
 # Flags
 IMPORT_ONLY=false
@@ -67,7 +72,7 @@ N8N_API_KEY="${N8N_API_KEY:-}"
 if [[ -z "$N8N_API_KEY" ]]; then
     log_warn "N8N_API_KEY nicht gesetzt."
     log_warn "Bitte in n8n UI generieren: Einstellungen → API → API Key erstellen"
-    log_warn "Dann N8N_API_KEY in ~/.openclaw/.env setzen und erneut ausführen."
+    log_warn "Dann N8N_API_KEY in $ENV_FILE setzen und erneut ausführen."
     log_warn "Workflows werden NICHT importiert."
     exit 0
 fi

--- a/ops/n8n/workflows/ai-review-escalation.json
+++ b/ops/n8n/workflows/ai-review-escalation.json
@@ -7,9 +7,15 @@
   },
   "pinData": {},
   "tags": [
-    { "name": "ai-review" },
-    { "name": "notifications" },
-    { "name": "discord" }
+    {
+      "name": "ai-review"
+    },
+    {
+      "name": "notifications"
+    },
+    {
+      "name": "discord"
+    }
   ],
   "nodes": [
     {
@@ -17,7 +23,10 @@
       "name": "Receive Escalation Payload",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [240, 260],
+      "position": [
+        240,
+        260
+      ],
       "webhookId": "ai-review-escalation",
       "parameters": {
         "httpMethod": "POST",
@@ -31,9 +40,12 @@
       "name": "Format Discord Alert Message",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [540, 260],
+      "position": [
+        540,
+        260
+      ],
       "parameters": {
-        "jsCode": "// Baut eine Discord Alert-Message f\u00fcr den Eskalations-Channel.\n// Input-Schema (von discord_notify.py in ai-review-pipeline):\n//   body.alert_type   'escalation' | 'disagreement' | 'soft_consensus'\n//   body.pr           string | number\n//   body.pr_url       string\n//   body.project      string\n//   body.stage        string (f\u00fcr escalation)\n//   body.iterations   number\n//   body.last_score   number | null\n//   body.summary      string (max 500 Zeichen)\n//   body.runbook_url  string\n//   body.rerun_cmd    string\n//   body.codex        {verdict, score} (f\u00fcr disagreement)\n//   body.cursor       {verdict, score} (f\u00fcr disagreement)\n//   body.avg_score    number (f\u00fcr soft_consensus)\n//   body.codex_score  number (f\u00fcr soft_consensus)\n//   body.cursor_score number (f\u00fcr soft_consensus)\n//   body.options      {approve, retry, timeout_minutes} (f\u00fcr soft_consensus)\n//\n// Ziel-Channel: DISCORD_ALERTS_CHANNEL_ID (aus env) oder body.channel_id\n// Mention: @here bei echten Eskalationen\n\nconst body = $json.body ?? $json ?? {};\n\nconst alertType = body.alert_type ?? body.event ?? 'escalation';\nconst pr        = body.pr ?? '?';\nconst prUrl     = body.pr_url ?? '';\nconst project   = body.project ?? '';\nconst runbook   = body.runbook_url ?? '';\nconst rerun     = body.rerun_cmd ?? '';\n\n// Channel: explizit im Payload oder Fallback auf ALERTS_CHANNEL_ID env-var\nconst channelId = String(\n  body.channel_id ??\n  $env.DISCORD_ALERTS_CHANNEL_ID ??\n  ''\n);\n\nif (!channelId) {\n  throw new Error(\n    'channel_id fehlt im Payload und DISCORD_ALERTS_CHANNEL_ID nicht gesetzt. ' +\n    'Bitte .ai-review/config.yaml oder ~/.openclaw/.env pr\u00fcfen.'\n  );\n}\n\nconst stageEmoji = {\n  code: '\\ud83e\\udd16',\n  'code-cursor': '\\ud83d\\udc31',\n  security: '\\ud83d\\udd12',\n  design: '\\ud83c\\udfa8',\n};\n\nlet content;\nlet shouldMention = true;  // @here bei echten Eskalationen\n\nif (alertType === 'soft_consensus' || alertType === 'ai-review/soft-consensus') {\n  shouldMention = false;  // soft_consensus = keine @here-Mention\n  const codexScore  = body.codex_score ?? '-';\n  const cursorScore = body.cursor_score ?? '-';\n  const avg         = body.avg_score ?? '?';\n  const opts        = body.options ?? {};\n\n  content = [\n    `\\u{1F914} **AI-Review soft-consensus** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `\\u{1F916} Codex: **${codexScore}/10**`,\n    `\\ud83d\\udc31 Cursor: **${cursorScore}/10**`,\n    `\\ud83d\\udcca Avg: **${avg}/10** (soft-zone 5\\u20138)`,\n    '',\n    'Die Code-Reviewer sehen es differenziert. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    '',\n    opts.approve ? `\\u2705 Approve: \\`${opts.approve}\\`` : '',\n    opts.retry   ? `\\ud83d\\udd01 Retry: \\`${opts.retry}\\`` : '',\n    opts.timeout_minutes ? `\\u23f1\\ufe0f Auto-Eskalation in ${opts.timeout_minutes} min` : '',\n    runbook ? `\\ud83d\\udcd6 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else if (alertType === 'disagreement' || alertType === 'ai-review/disagreement') {\n  const codex  = body.codex ?? {};\n  const cursor = body.cursor ?? {};\n  const fmt    = r => `${r.verdict ?? '?'} (${r.score ?? '-'}/10)`;\n\n  content = [\n    `\\u{1F914} **AI-Review Disagreement** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '@here',\n    '',\n    `\\u{1F916} Codex: **${fmt(codex)}**`,\n    `\\ud83d\\udc31 Cursor: **${fmt(cursor)}**`,\n    '',\n    'Die beiden Code-Reviewer sind uneinig. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else {\n  // Standard: Circuit-Breaker Eskalation\n  const stage      = body.stage ?? 'unknown';\n  const iterations = body.iterations ?? '?';\n  const lastScore  = body.last_score ?? null;\n  const summary    = String(body.summary ?? '').slice(0, 500);\n  const stageE     = stageEmoji[stage] || '\\u2699\\ufe0f';\n  const scoreLine  = lastScore !== null && lastScore !== undefined\n    ? `**Score:** ${lastScore}/10`\n    : '';\n\n  content = [\n    `\\u26a0\\ufe0f **AI Review Escalation** @here`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `${stageE} **Stage:** ${stage}`,\n    `**PR:** #${pr}`,\n    scoreLine,\n    `**Iterations:** ${iterations} (circuit-breaker)`,\n    '',\n    summary ? `**Letzter Hinweis:**\\n\\`\\`\\`\\n${summary}\\n\\`\\`\\`` : '',\n    '',\n    prUrl   ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n}\n\nreturn [{\n  json: {\n    channel_id: channelId,\n    content,\n    alert_type: alertType,\n    pr_number: String(pr),\n  },\n}];\n"
+        "jsCode": "// Baut eine Discord Alert-Message f\u00fcr den Eskalations-Channel.\n// Input-Schema (von discord_notify.py in ai-review-pipeline):\n//   body.alert_type   'escalation' | 'disagreement' | 'soft_consensus'\n//   body.pr           string | number\n//   body.pr_url       string\n//   body.project      string\n//   body.stage        string (f\u00fcr escalation)\n//   body.iterations   number\n//   body.last_score   number | null\n//   body.summary      string (max 500 Zeichen)\n//   body.runbook_url  string\n//   body.rerun_cmd    string\n//   body.codex        {verdict, score} (f\u00fcr disagreement)\n//   body.cursor       {verdict, score} (f\u00fcr disagreement)\n//   body.avg_score    number (f\u00fcr soft_consensus)\n//   body.codex_score  number (f\u00fcr soft_consensus)\n//   body.cursor_score number (f\u00fcr soft_consensus)\n//   body.options      {approve, retry, timeout_minutes} (f\u00fcr soft_consensus)\n//\n// Ziel-Channel: DISCORD_ALERTS_CHANNEL_ID (aus env) oder body.channel_id\n// Mention: @here bei echten Eskalationen\n\nconst body = $json.body ?? $json ?? {};\n\nconst alertType = body.alert_type ?? body.event ?? 'escalation';\nconst pr        = body.pr ?? '?';\nconst prUrl     = body.pr_url ?? '';\nconst project   = body.project ?? '';\nconst runbook   = body.runbook_url ?? '';\nconst rerun     = body.rerun_cmd ?? '';\n\n// Channel: explizit im Payload oder Fallback auf ALERTS_CHANNEL_ID env-var\nconst channelId = String(\n  body.channel_id ??\n  $env.DISCORD_ALERTS_CHANNEL_ID ??\n  ''\n);\n\nif (!channelId) {\n  throw new Error(\n    'channel_id fehlt im Payload und DISCORD_ALERTS_CHANNEL_ID nicht gesetzt. ' +\n    'Bitte .ai-review/config.yaml oder ~/.config/ai-workflows/env pr\u00fcfen.'\n  );\n}\n\nconst stageEmoji = {\n  code: '\\ud83e\\udd16',\n  'code-cursor': '\\ud83d\\udc31',\n  security: '\\ud83d\\udd12',\n  design: '\\ud83c\\udfa8',\n};\n\nlet content;\nlet shouldMention = true;  // @here bei echten Eskalationen\n\nif (alertType === 'soft_consensus' || alertType === 'ai-review/soft-consensus') {\n  shouldMention = false;  // soft_consensus = keine @here-Mention\n  const codexScore  = body.codex_score ?? '-';\n  const cursorScore = body.cursor_score ?? '-';\n  const avg         = body.avg_score ?? '?';\n  const opts        = body.options ?? {};\n\n  content = [\n    `\\u{1F914} **AI-Review soft-consensus** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `\\u{1F916} Codex: **${codexScore}/10**`,\n    `\\ud83d\\udc31 Cursor: **${cursorScore}/10**`,\n    `\\ud83d\\udcca Avg: **${avg}/10** (soft-zone 5\\u20138)`,\n    '',\n    'Die Code-Reviewer sehen es differenziert. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    '',\n    opts.approve ? `\\u2705 Approve: \\`${opts.approve}\\`` : '',\n    opts.retry   ? `\\ud83d\\udd01 Retry: \\`${opts.retry}\\`` : '',\n    opts.timeout_minutes ? `\\u23f1\\ufe0f Auto-Eskalation in ${opts.timeout_minutes} min` : '',\n    runbook ? `\\ud83d\\udcd6 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else if (alertType === 'disagreement' || alertType === 'ai-review/disagreement') {\n  const codex  = body.codex ?? {};\n  const cursor = body.cursor ?? {};\n  const fmt    = r => `${r.verdict ?? '?'} (${r.score ?? '-'}/10)`;\n\n  content = [\n    `\\u{1F914} **AI-Review Disagreement** \\u2014 PR #${pr}`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '@here',\n    '',\n    `\\u{1F916} Codex: **${fmt(codex)}**`,\n    `\\ud83d\\udc31 Cursor: **${fmt(cursor)}**`,\n    '',\n    'Die beiden Code-Reviewer sind uneinig. Bitte kurz reinschauen.',\n    '',\n    prUrl ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n\n} else {\n  // Standard: Circuit-Breaker Eskalation\n  const stage      = body.stage ?? 'unknown';\n  const iterations = body.iterations ?? '?';\n  const lastScore  = body.last_score ?? null;\n  const summary    = String(body.summary ?? '').slice(0, 500);\n  const stageE     = stageEmoji[stage] || '\\u2699\\ufe0f';\n  const scoreLine  = lastScore !== null && lastScore !== undefined\n    ? `**Score:** ${lastScore}/10`\n    : '';\n\n  content = [\n    `\\u26a0\\ufe0f **AI Review Escalation** @here`,\n    project ? `Projekt: \\`${project}\\`` : '',\n    '',\n    `${stageE} **Stage:** ${stage}`,\n    `**PR:** #${pr}`,\n    scoreLine,\n    `**Iterations:** ${iterations} (circuit-breaker)`,\n    '',\n    summary ? `**Letzter Hinweis:**\\n\\`\\`\\`\\n${summary}\\n\\`\\`\\`` : '',\n    '',\n    prUrl   ? `**PR:** ${prUrl}` : '',\n    rerun   ? `\\u2022 Re-Trigger: \\`${rerun}\\`` : '',\n    runbook ? `\\u2022 Runbook: ${runbook}` : '',\n  ].filter(Boolean).join('\\n');\n}\n\nreturn [{\n  json: {\n    channel_id: channelId,\n    content,\n    alert_type: alertType,\n    pr_number: String(pr),\n  },\n}];\n"
       }
     },
     {
@@ -41,21 +53,32 @@
       "name": "POST Alert to Discord Alerts Channel",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [860, 260],
+      "position": [
+        860,
+        260
+      ],
       "parameters": {
         "method": "POST",
         "url": "={{ 'https://discord.com/api/v10/channels/' + $json.channel_id + '/messages' }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
-            { "name": "Authorization", "value": "=Bot {{ $env.DISCORD_BOT_TOKEN }}" },
-            { "name": "Content-Type", "value": "application/json" }
+            {
+              "name": "Authorization",
+              "value": "=Bot {{ $env.DISCORD_BOT_TOKEN }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ { content: $json.content } }}",
-        "options": { "timeout": 10000 }
+        "options": {
+          "timeout": 10000
+        }
       }
     },
     {
@@ -63,7 +86,10 @@
       "name": "Respond 200 OK",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1160, 260],
+      "position": [
+        1160,
+        260
+      ],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ { ok: true, delivered_at: new Date().toISOString(), alert_type: $('Format Discord Alert Message').item.json.alert_type, pr: $('Format Discord Alert Message').item.json.pr_number } }}"
@@ -74,21 +100,33 @@
     "Receive Escalation Payload": {
       "main": [
         [
-          { "node": "Format Discord Alert Message", "type": "main", "index": 0 }
+          {
+            "node": "Format Discord Alert Message",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
     "Format Discord Alert Message": {
       "main": [
         [
-          { "node": "POST Alert to Discord Alerts Channel", "type": "main", "index": 0 }
+          {
+            "node": "POST Alert to Discord Alerts Channel",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
     "POST Alert to Discord Alerts Channel": {
       "main": [
         [
-          { "node": "Respond 200 OK", "type": "main", "index": 0 }
+          {
+            "node": "Respond 200 OK",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     }


### PR DESCRIPTION
## Summary

Folge-PR zu #3 (env-domain-separation). Alle ops/-Scripts die AI-Review-Secrets lesen, sind jetzt auf den neuen Secrets-SoT umgestellt: `${AI_WORKFLOWS_ENV:-~/.config/ai-workflows/env}`.

## Why

PR#3 führte die Domain-Separation für den n8n-Container (via compose-override) ein. Die ops/-Scripts selbst referenzierten aber weiterhin `~/.openclaw/.env` direkt — Drift-Risiko. Dieser PR räumt auf.

## Changes

| File | Change |
|---|---|
| `ops/discord-bot/init-server.sh` | ENV_FILE default `~/.config/ai-workflows/env`, override via `AI_WORKFLOWS_ENV` |
| `ops/discord-bot/setup.sh` | ENV_FILE override + header-comment update |
| `ops/discord-bot/provision_channels.py` | Error-message auf neuen Pfad |
| `ops/n8n/scripts/setup-ops-n8n.sh` | ENV_FILE override + header-note zu consolidated-primary |
| `ops/n8n/scripts/backup-ops-n8n.sh` | ENV_FILE + BACKUP_DIR override |
| `ops/n8n/docker-compose.yml` | env_file auf neuen Pfad (optional-fallback klar markiert) |
| `ops/n8n/README.md` | Rewrite: konsolidiertes Setup primary, docker-compose.yml optional |
| `ops/n8n/workflows/*.json` | Error-message-Strings im jsCode auf neuen Pfad |

## NOT in scope

- `install.sh` + `.env.example` (globale agent-stack bootstrap, MCP-Keys — separater Refactor wenn OpenClaw vollständig von agent-stack getrennt werden soll)
- `ops/compose/n8n-ai-review.override.yml` behält additiven mount auf `~/.openclaw/.env` — nötig damit ai-portal-Business-Workflows weiter ihre bestehenden Credentials lesen

## Test plan

- [x] bash -n auf alle 4 Scripts: pass
- [x] shellcheck -x -e SC1091: pass (0 warnings)
- [x] JSON-Syntax workflows nach Patch: valid (load + dump clean)
- [x] Live-Deployment läuft bereits mit diesem Pfad (r2d2 ops-n8n-ai-review container)
- [x] E2E-Discord-Bridge funktioniert weiterhin (siehe PR#3/#4 Evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)