### PR TITLE
feat(hooks): SessionStart project-setup-check + AGENTS.md §8 Extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,48 @@ Details: `github.com/EtroxTaran/ai-review-pipeline`.
 `codex: gpt-5.x` · `cursor: composer-2` · `gemini: gemini-2.5-pro` · `claude: claude-opus-4-7`.
 Pro Projekt überschreibbar via `.ai-review/config.yaml`.
 
+### Project-Setup-Step (automatisch bei Session-Start)
+
+Jedes Projekt unter `github.com/EtroxTaran/*` MUSS die Review-Pipeline aktiviert haben.
+Der SessionStart-Hook `~/.claude/hooks/project-setup-check.sh` prüft das bei jedem
+Claude-Code-Start automatisch und printet — falls nicht konfiguriert — eine
+handlungsbare Anleitung:
+
+```
+┌────────────────────────────────────────────────┐
+│ ⚠️  AI-Review-Pipeline nicht aktiviert         │
+│                                                │
+│ Setup (~5 Min):                                │
+│   gh ai-review install                         │
+│   $EDITOR .ai-review/config.yaml               │
+│   gh ai-review verify                          │
+└────────────────────────────────────────────────┘
+```
+
+**Der Agent (Claude / Cursor / Gemini / Codex) liest diesen Output im Session-Start
+und MUSS beim ersten nicht-trivialen User-Request:**
+
+1. Den Nudge erwähnen (einmal pro Session, nicht wiederholen)
+2. Anbieten, das Setup auszuführen (falls User-Intent = "neues Projekt aufsetzen")
+3. Bei Ablehnung: respektieren, nicht drängen
+
+**Bypass-Mechanismen** (wenn ein Repo bewusst ohne Pipeline läuft):
+- `touch .ai-review/.noreview && git add … && git commit` im Repo
+- `CLAUDE_SKIP_AI_REVIEW_SETUP=1` als Environment-Variable
+- Fremd-Repos (nicht `EtroxTaran/*`): Hook feuert nicht
+
+**Setup-Ablauf** (Details: `agent-stack/docs/wiki/40-setup/00-quickstart-neues-projekt.md`):
+1. `gh ai-review install` — kopiert 10 Workflow-Templates + `.ai-review/config.yaml`
+2. `$EDITOR .ai-review/config.yaml` — Discord-Channel-ID eintragen
+3. `gh ai-review verify` — Sanity-Check (Templates da, Config-Schema valid, Secrets gesetzt)
+4. `bash ~/projects/agent-stack/ops/discord-bot/init-server.sh --add-project <name>` — Channels anlegen
+5. PR öffnen → Branch-Protection konfigurieren (`ai-review/consensus` als Required-Check)
+
+**Warum als Hook und nicht als "bitte dran denken"**: Der Hook ist deterministisch,
+der Mensch vergisst. Informationelle CLAUDE.md-Notizen werden vom Agent ignoriert
+wenn der Session-Kontext voll ist — ein Bash-Output beim Session-Start ist
+garantiert sichtbar.
+
 ---
 
 ## 9. Ticket ↔ PR Linkage (strikt)

--- a/configs/claude/hooks/project-setup-check.sh
+++ b/configs/claude/hooks/project-setup-check.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# project-setup-check.sh — SessionStart-Hook
+#
+# Feuert bei jedem neuen Claude-Code-Session-Start via ~/.claude/settings.json
+# `hooks.SessionStart`. Erkennt Projekte die die AI-Review-Pipeline nutzen
+# könnten aber noch nicht konfiguriert sind, und printet eine klar handlungs-
+# bare Anleitung in den Session-Start-Output.
+#
+# Design-Ziele:
+#   - Kein Noise in Non-Git-Ordnern oder bereits-konfigurierten Repos
+#   - Zeigt nur Info (exit 0), blockt den Session-Start nicht
+#   - Skippbar via CLAUDE_SKIP_AI_REVIEW_SETUP=1 (für CI, temp-Dirs etc.)
+#   - Idempotent und absichtsicher — läuft auch ohne gh-Extension sauber durch
+
+set -euo pipefail
+
+# ── Abbruch-Bedingungen ─────────────────────────────────────────────────
+
+# Explizit-Skip (z.B. CI, Temp-Dirs, experimentelle Ordner)
+if [ "${CLAUDE_SKIP_AI_REVIEW_SETUP:-0}" = "1" ]; then
+    exit 0
+fi
+
+# Nicht in einem Git-Repo → nichts zu tun
+if [ ! -d ".git" ] && ! git rev-parse --git-dir >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Pipeline bereits konfiguriert → nichts zu tun
+if [ -f ".ai-review/config.yaml" ] && \
+   [ -f ".github/workflows/ai-code-review.yml" ]; then
+    exit 0
+fi
+
+# Repo ist explizit als "kein AI-Review"-Repo markiert
+if [ -f ".ai-review/.noreview" ] || \
+   [ -f ".noaireview" ]; then
+    exit 0
+fi
+
+# ── Repo-Typ erkennen ───────────────────────────────────────────────────
+# Nur Repos auf dem User-Account interessieren; fremde Forks ignorieren
+readonly EXPECTED_OWNER="${AI_REVIEW_EXPECTED_OWNER:-EtroxTaran}"
+
+REMOTE_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
+if [ -z "$REMOTE_URL" ]; then
+    # Lokales Repo ohne Remote — kein Setup-Nudge
+    exit 0
+fi
+
+if ! echo "$REMOTE_URL" | grep -qE "[/:]${EXPECTED_OWNER}/"; then
+    # Fremdes Repo (nicht EtroxTaran) → kein Setup-Nudge
+    exit 0
+fi
+
+# ── Setup-Fähigkeit prüfen ──────────────────────────────────────────────
+
+# gh-CLI verfügbar?
+if ! command -v gh >/dev/null 2>&1; then
+    cat <<'EOF'
+
+ℹ️  AI-Review-Pipeline ist für dieses Repo noch nicht konfiguriert.
+   Installation braucht `gh` CLI — siehe agent-stack/docs/wiki/40-setup/
+EOF
+    exit 0
+fi
+
+# gh ai-review Extension installiert?
+if ! gh ai-review --help >/dev/null 2>&1; then
+    cat <<'EOF'
+
+ℹ️  AI-Review-Pipeline ist für dieses Repo noch nicht konfiguriert.
+   Voraussetzung: `gh extension install EtroxTaran/gh-ai-review`
+
+   Danach: `gh ai-review install` im Repo-Root.
+
+   Details: agent-stack/docs/wiki/40-setup/00-quickstart-neues-projekt.md
+EOF
+    exit 0
+fi
+
+# ── Nudge ausgeben ──────────────────────────────────────────────────────
+REPO_NAME=$(basename "$(pwd)")
+
+cat <<EOF
+
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚠️  AI-Review-Pipeline nicht aktiviert in '$REPO_NAME'
+├─────────────────────────────────────────────────────────────────┤
+│  Jedes Projekt unter $EXPECTED_OWNER sollte die Review-Pipeline
+│  haben (5 Stages + Consensus + Discord-Notifications).
+│
+│  Setup (~5 Min):
+│    gh ai-review install
+│    $EDITOR .ai-review/config.yaml    # Discord-Channel eintragen
+│    gh ai-review verify               # Sanity-Check
+│
+│  Skip (für dieses Repo dauerhaft):
+│    touch .ai-review/.noreview && git add … && git commit …
+│
+│  Details: agent-stack/docs/wiki/40-setup/00-quickstart-neues-projekt.md
+└─────────────────────────────────────────────────────────────────┘
+
+EOF
+
+# Exit 0 = informativ, non-blocking
+exit 0

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -62,6 +62,17 @@
     "defaultMode": "acceptEdits"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/project-setup-check.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

Macht die AI-Review-Pipeline zum **Standard-Setup-Step für jedes neue Projekt** unter `EtroxTaran/*`, indem ein SessionStart-Hook bei jedem Claude-Code-Start prüft, ob das aktuelle Repo die Pipeline aktiviert hat — und bei Nicht-Aktivierung eine klar handlungsbare Anleitung printet.

## Problem

Bisher war die Pipeline **opt-in pro Projekt**: `gh ai-review install` musste manuell in jedem neuen Repo ausgeführt werden. Es gab keinen Mechanismus, der Agents / User daran erinnert. Informationelle AGENTS.md-Notizen ("bitte dran denken") werden bei vollem Kontext-Window ignoriert.

## Lösung

Zwei-teilig:

1. **SessionStart-Hook** (`configs/claude/hooks/project-setup-check.sh`) — deterministischer Bash-Check bei jedem Session-Start
2. **AGENTS.md §8-Extension** — dokumentiert den Hook + definiert was der Agent beim ersten User-Request tun soll

## Design-Entscheidungen

- **SessionStart** ist der dokumentierte Hook-Type für Session-Initialisierung (Research via claude-code-guide)
- **Exit 0 + Info-Output** statt blocking exit 1 — der Setup-Step ist ein Vorschlag, kein Zwang
- **3 Bypass-Mechanismen**: `CLAUDE_SKIP_AI_REVIEW_SETUP=1` (env), `.ai-review/.noreview` (per-repo), Fremd-Repos nicht-`EtroxTaran/*` (default skip)
- **gh-CLI-Check integriert**: Wenn `gh ai-review`-Extension noch nicht installiert ist, wird stattdessen die Extension-Install-Anleitung gezeigt

## Output-Beispiel (in un-konfiguriertem EtroxTaran-Repo)

```
┌─────────────────────────────────────────────────────────────────┐
│  ⚠️  AI-Review-Pipeline nicht aktiviert in '<repo-name>'
├─────────────────────────────────────────────────────────────────┤
│  Setup (~5 Min):
│    gh ai-review install
│    $EDITOR .ai-review/config.yaml    # Discord-Channel eintragen
│    gh ai-review verify               # Sanity-Check
│
│  Skip (für dieses Repo dauerhaft):
│    touch .ai-review/.noreview && git add … && git commit …
│
│  Details: agent-stack/docs/wiki/40-setup/00-quickstart-neues-projekt.md
└─────────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] Hook-Syntax OK (`bash -n project-setup-check.sh`)
- [x] `settings.json` Schema-valid (`python3 -m json.tool`)
- [x] Smoke-Test in agent-stack-Repo (ohne `.ai-review/config.yaml`): zeigt Nudge korrekt
- [x] Smoke-Test in `/tmp` (non-git): exit 0 silent
- [x] `CLAUDE_SKIP_AI_REVIEW_SETUP=1` übersteuert: exit 0 silent
- [x] Symlinks live: `~/.claude/settings.json` enthält SessionStart-Block, `~/.claude/hooks/project-setup-check.sh` executable
- [ ] End-to-end: Claude-Code-Session-Start zeigt Nudge (manuell beim nächsten Start validierbar)

## Referenzen

- Research zu Best-Practices: claude-code-guide Subagent (SessionStart hook > skill-auto-trigger > project-local CLAUDE.md)
- AGENTS.md §8.3 "Project-Setup-Step" (neuer Abschnitt)
- Wiki: [`40-setup/00-quickstart-neues-projekt.md`](https://github.com/EtroxTaran/agent-stack/blob/main/docs/wiki/40-setup/00-quickstart-neues-projekt.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)