### PR TITLE
docs: Wiki auf Phase-5-Cutover aktualisiert

### DIFF
--- a/docs/wiki/10-konzepte/20-shadow-vs-cutover.md
+++ b/docs/wiki/10-konzepte/20-shadow-vs-cutover.md
@@ -75,10 +75,10 @@ Wenn nach Schritt 4 herauskommt, dass v2 nicht zuverlässig ist: Branch-Protecti
 
 ### Aktueller Status (Stand dieses Dokuments)
 
-- **Phase 4 läuft stabil** seit dem Merge von PR#40 (ai-portal Shadow-Mode Hook)
-- Shadow-Run #24853468198 zeigte 6/6 Jobs success + Consensus success — ein erster vollständig sauberer Durchlauf
-- Divergenz-Analyse noch ausstehend (braucht mehr Real-PRs zum Vergleich)
-- Phase 5 Cutover: frühestens nach 10+ Real-PRs durch v2 mit dokumentiertem Divergenz-Bericht
+- **Phase 5 Cutover durchgeführt** am 2026-04-24 (ai-portal PR#44)
+- v2 ist **die einzige Pipeline** im ai-portal; v1 Legacy-Workflows gelöscht
+- Shadow-Phase 4 war von 2026-04-20 (Hook-Merge) bis 2026-04-24 aktiv
+- Shadow-Run #24853468198 lieferte den grünen E2E-Nachweis vor dem Cutover
 
 ## Verwandte Seiten
 
@@ -89,6 +89,6 @@ Wenn nach Schritt 4 herauskommt, dass v2 nicht zuverlässig ist: Branch-Protecti
 
 ## Quelle der Wahrheit (SoT)
 
-- [`ai-portal/.github/workflows/ai-review-v2-shadow.yml`](https://github.com/EtroxTaran/ai-portal/blob/main/.github/workflows/ai-review-v2-shadow.yml) — der v2 Shadow-Workflow
-- [`ai-portal/.ai-review/config.yaml`](https://github.com/EtroxTaran/ai-portal/blob/main/.ai-review/config.yaml) — Phase-4-Config
+- [`ai-portal/.github/workflows/ai-review.yml`](https://github.com/EtroxTaran/ai-portal/blob/main/.github/workflows/ai-review.yml) — der Production-Workflow (seit Cutover 2026-04-24)
+- [`ai-portal/.ai-review/config.yaml`](https://github.com/EtroxTaran/ai-portal/blob/main/.ai-review/config.yaml) — Production-Config
 - [ADR-018 CI/CD Deploy Pipeline](https://github.com/EtroxTaran/ai-portal/blob/main/docs/v2/10-adr/ADR-018-cicd-deploy-pipeline.md) — Architektur-Entscheidung

--- a/docs/wiki/80-historie/00-changelog.md
+++ b/docs/wiki/80-historie/00-changelog.md
@@ -2,6 +2,21 @@
 
 > **TL;DR:** Diese Seite listet die größeren Entwicklungsschritte der AI-Review-Toolchain in umgekehrter chronologischer Reihenfolge. Für Detail-Analyse einzelner Entscheidungen siehe [ADRs-Index](20-adrs-index.md); für die sich-daraus-ergebenden Lehren siehe [Lessons Learned](10-lessons-learned.md). Dieser Changelog fokussiert auf: Was wurde gebaut, wann, warum grob.
 
+## 2026-04-24 — Phase-5-Cutover im ai-portal (PR#44)
+
+**Was:** v2 ai-review-pipeline wird die **einzige** Review-Pipeline im ai-portal. Shadow-Modus beendet, 5 v1-Legacy-Workflows gelöscht.
+**Warum:** Die Toolchain wurde für Produktions-Einsatz gebaut; paralleler Shadow-Betrieb sollte nur Validierung sein, nicht Dauerzustand. Nico hat explizit Cutover sofort angeordnet.
+**Die Schritte:**
+1. `.ai-review/config.yaml`: alle 5 Stages `blocking: true`, Channel-ID auf `${DISCORD_CHANNEL_AI_PORTAL}`, `mention_role: "@here"`
+2. `ai-review-v2-shadow.yml` → `ai-review.yml` (Rename via `git mv`)
+3. `--status-context-prefix ai-review-v2`, `--discord-channel`, `--no-ping` Shadow-Flags entfernt
+4. Metrics-Pfad `.ai-review/metrics-v2.jsonl` → `.ai-review/metrics.jsonl`
+5. 5 Legacy-Workflows gelöscht: `ai-code-review.yml`, `ai-security-review.yml`, `ai-design-review.yml`, `ai-review-scope-check.yml`, `ai-review-consensus.yml`
+
+**Branch-Protection:** `ai-review/consensus` war bereits als required-check konfiguriert — kein Gap beim Cutover.
+
+**Referenz:** [ai-portal PR#44](https://github.com/EtroxTaran/ai-portal/pull/44).
+
 ## 2026-04-23 — Projekt-Setup-Hook (PR#9)
 
 **Was:** SessionStart-Hook `project-setup-check.sh`, der bei jedem Claude-Code-Session-Start erkennt, ob das aktuelle Repo die AI-Review-Pipeline aktiviert hat.


### PR DESCRIPTION
## Summary

- Wiki-Status-Sektion in `shadow-vs-cutover.md` zeigt jetzt "Phase 5 Cutover durchgeführt 2026-04-24"
- Neuer Changelog-Eintrag für ai-portal PR#44 mit Schritt-für-Schritt-Dokumentation
- SoT-Link zeigt auf den umbenannten `ai-review.yml` (statt `ai-review-v2-shadow.yml`)

Spiegel zu ai-portal PR#44 — hält das Wiki in sync mit der Realität.

## Test plan

- [ ] Link `ai-review.yml` öffnet die neue Datei in ai-portal/main (nach Merge von PR#44)
- [ ] Changelog-Reihenfolge chronologisch korrekt (2026-04-24 vor 2026-04-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)