### PR TITLE
fix(drift-check): skip OpenAI-API-Tier (Codex-Subscription ist SoT)

### DIFF
--- a/scripts/model-registry-drift-check.py
+++ b/scripts/model-registry-drift-check.py
@@ -112,7 +112,20 @@ def fetch_anthropic_models(api_key: str) -> dict[str, str]:
 
 
 def fetch_openai_models(api_key: str) -> dict[str, str]:
-    """Fetch OpenAI-Modelle via /v1/models — Heuristik für Codex-Variante."""
+    """Fetch OpenAI-Modelle via /v1/models — Heuristik für Codex-Variante.
+
+    WARNUNG: Die OpenAI-REST-API listet den API-Tier-Katalog. Bei Codex-CLI-
+    Nutzung via ChatGPT-Plus/Pro-Subscription ist der Codex-Subscription-
+    Katalog (`chatgpt.com/backend-api/codex/models`) autoritativ — der hat
+    typischerweise aktuellere Modelle (z.B. `gpt-5.5` war dort Tage früher
+    sichtbar als im API-Tier). Diese Funktion wird deshalb im GH-Actions-
+    Weekly-Drift-Check NICHT mehr direkt genutzt — stattdessen übernimmt der
+    lokale tägliche Cron (`~/.openclaw/workspace/scripts/model-version-check.py
+    → fetch_codex_chatgpt()`) die OPENAI_MAIN-Pflege. Hier nur als Fallback
+    für Fälle, wo keine OAuth-Credentials vorhanden sind (Drittnutzer fork).
+
+    Siehe: ~/.claude/projects/-home-clawd/memory/feedback_openai_uses_codex_subscription.md
+    """
     try:
         data = _http_json(
             "https://api.openai.com/v1/models",
@@ -353,11 +366,22 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("⏭️  ANTHROPIC_API_KEY nicht gesetzt — skip Anthropic")
 
-    if openai_key:
-        print("🔍 Fetch OpenAI…")
+    # OpenAI: SKIP im GH-Actions-Weekly. API-Tier (/v1/models) lagt dem
+    # Codex-Subscription-Katalog (chatgpt.com/backend-api/codex/models)
+    # hinterher — ein Fetch von hier würde OPENAI_MAIN=gpt-5.5 fälschlich
+    # auf gpt-5.4 zurückdrücken. Die OpenAI-Pins werden ausschließlich vom
+    # lokalen täglichen Cron (`~/.openclaw/workspace/scripts/model-version-
+    # check.py`) mit OAuth-Subscription-Access gepflegt.
+    # Force-flag AI_REVIEW_DRIFT_CHECK_OPENAI_API=1 erzwingt API-Tier-Fetch
+    # trotzdem (für Downstream-Forks ohne Codex-Subscription).
+    if openai_key and os.environ.get("AI_REVIEW_DRIFT_CHECK_OPENAI_API") == "1":
+        print("🔍 Fetch OpenAI (API-Tier, forced via env-var)…")
         candidates.update(fetch_openai_models(openai_key))
     else:
-        print("⏭️  OPENAI_API_KEY nicht gesetzt — skip OpenAI")
+        print(
+            "⏭️  OpenAI skip — SoT ist Codex-Subscription (lokaler Cron). "
+            "API-Tier-Fetch via AI_REVIEW_DRIFT_CHECK_OPENAI_API=1 erzwingbar."
+        )
 
     if gemini_key:
         print("🔍 Fetch Gemini…")


### PR DESCRIPTION
## Summary

Memory-Feedback aus aktueller Session: OpenAI-Modell-Infos kommen bei uns aus der **Codex-Subscription** via ChatGPT-backend OAuth, NICHT aus `api.openai.com/v1/models`. Letzteres lagt (gpt-5.5 war in Subscription früher verfügbar als API-Tier).

Der GH-Actions-Weekly-Drift-Check fetcht aus \`api.openai.com\` — das würde `OPENAI_MAIN=gpt-5.5` fälschlich auf `gpt-5.4` zurückdrücken beim nächsten Run.

**Fix:** Skip OpenAI im Weekly-Drift-Check. Lokaler täglicher Cron (`~/.openclaw/workspace/scripts/model-version-check.py`) hat OAuth-Zugriff und ist SoT für OPENAI_MAIN.

**Escape hatch:** `AI_REVIEW_DRIFT_CHECK_OPENAI_API=1` Env-Var erzwingt den API-Tier-Fetch (für Forks ohne Codex-Subscription).

## Architektur nach diesem PR

| Quelle | Verantwortlichkeit | Wann |
|---|---|---|
| Local Cron (`model-version-check.py → fetch_codex_chatgpt()`) | OPENAI_MAIN via OAuth | Täglich 04:00 |
| GH-Actions (`model-registry-drift-check.py`) | ANTHROPIC_*, GEMINI_*, CLI-Versions | Montag 08:00 UTC |

## Referenz

Memory: `~/.claude/projects/-home-clawd/memory/feedback_openai_uses_codex_subscription.md`

## Tests

- `pytest tests/test_model_registry_drift_check.py` → 16/16 green (unverändert — die Tests rufen `fetch_openai_models` direkt auf; die Skip-Policy ist in `main()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)