### PR TITLE
feat(skills): konsolidiere cross-CLI auf ~/.agents/skills/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,10 @@ Enforcement: Verletzung → Lessons-Learned-Eintrag + sofortige Korrektur + Memo
 ## 14. Skills — Cross-Tool Standard
 
 - **Format**: Agent Skills Open Standard (`SKILL.md` YAML-Frontmatter + Markdown).
-  Eine Quelle in `agent-stack/skills/`, via dotbot symlinked in `~/.{claude,cursor,gemini,codex}/skills/`.
+  Eine Quelle in `agent-stack/skills/`, via dotbot symlinked in:
+  - `~/.agents/skills/<name>` — **Primär-SoT**, nativ gelesen von **Codex** (offizielle Docs: [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills)) und **Gemini** ([geminicli.com/docs/cli/skills](https://geminicli.com/docs/cli/skills/)).
+  - `~/.claude/skills/<name>` — redundanter Symlink für Claude (erwartet seinen eigenen Pfad).
+  - **Cursor** hat aktuell keinen nativen Skills-Support (Forum-Antwort Cursor-Mod, 2026-04). Plan: MCP-Bridge (Follow-up).
 - **Tool-neutral**: Keine CLI-spezifischen Bash-Calls in Skills (`claude …`, `cursor-agent …`).
   Nur generische MCP-Tools + Standard-Bash.
 - **Authoring-Workflow** (Anthropic Skill-Creator):
@@ -443,7 +446,7 @@ Details: `~/.openclaw/workspace/AGENTS.md` §6 + `docs/extended-rules.md`.
 ## 17. Wichtige Pfade
 
 - **Workspace (OpenClaw)**: `~/.openclaw/workspace/`
-- **Skills (Cross-Tool-SoT)**: `~/projects/agent-stack/skills/` → symlinked in `~/.{claude,cursor,gemini,codex}/skills/`
+- **Skills (Cross-Tool-SoT)**: `~/projects/agent-stack/skills/` → symlinked in `~/.agents/skills/` (primär) + `~/.claude/skills/` (redundant für Claude-Pfad-Erwartung)
 - **Scripts (OpenClaw)**: `~/.openclaw/workspace/scripts/`
 - **Env (Secrets-SoT)**: `~/.openclaw/.env` — **NIE** im Repo committen
 - **Projects**: `~/projects/`

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -1,8 +1,19 @@
 # dotbot manifest — declarative symlinks for all 4 CLIs.
-# Source of truth: files in this repo. Targets: ~/.claude, ~/.cursor, ~/.gemini, ~/.codex
+# Source of truth: files in this repo. Targets: ~/.claude, ~/.cursor, ~/.gemini, ~/.codex, ~/.agents
 #
 # IMPORTANT: force: false — dotbot never overwrites real files silently.
 # Backup of existing real files is done beforehand by scripts/backup-existing.sh.
+#
+# Skills-Pfad-Konsolidierung (Issue #22, verifiziert 2026-04-24):
+# - Codex liest ~/.agents/skills/ (NICHT ~/.codex/skills/)
+# - Gemini akzeptiert ~/.agents/skills/ oder ~/.gemini/skills/
+# - Claude erwartet ~/.claude/skills/
+# - Cursor hat keinen nativen Skills-Support — siehe Follow-up-Issue für MCP-Bridge
+#
+# Deshalb:
+# - ~/.agents/skills/<name> ist Primär-SoT für Codex + Gemini (deckt beide via offizielle Docs)
+# - ~/.claude/skills/<name> redundanter Symlink ins Repo (Claude-Pfad-Erwartung)
+# - ~/.codex/skills/ und ~/.cursor/skills/ sind entfernt (ineffektiv)
 
 - defaults:
     link:
@@ -15,18 +26,46 @@
 # ACHTUNG: keine Pfade hier, die weiter unten per `link:` als Symlink gesetzt werden
 # (wie ~/.claude/hooks), sonst blockiert die vorab angelegte Leer-Directory den Symlink.
 - create:
+    - ~/.agents
+    - ~/.agents/skills
     - ~/.claude
     - ~/.claude/skills
     - ~/.cursor
     - ~/.cursor/rules
-    - ~/.cursor/skills
     - ~/.gemini
-    - ~/.gemini/skills
     - ~/.codex
-    - ~/.codex/skills
 
 # ---------------------------------------------------------------------------
-# Claude Code
+# Skills — Primärer SoT-Pfad (Codex + Gemini nativ)
+# ---------------------------------------------------------------------------
+- link:
+    ~/.agents/skills/ac-validate:
+      path: skills/ac-validate
+    ~/.agents/skills/ac-waiver:
+      path: skills/ac-waiver
+    ~/.agents/skills/code-review-expert:
+      path: skills/code-review-expert
+    ~/.agents/skills/design-review:
+      path: skills/design-review
+    ~/.agents/skills/issue-pickup:
+      path: skills/issue-pickup
+    ~/.agents/skills/nachfrage-respond:
+      path: skills/nachfrage-respond
+    ~/.agents/skills/pr-open:
+      path: skills/pr-open
+    ~/.agents/skills/release-checklist:
+      path: skills/release-checklist
+    ~/.agents/skills/review-gate:
+      path: skills/review-gate
+    ~/.agents/skills/security-audit:
+      path: skills/security-audit
+    ~/.agents/skills/security-waiver:
+      path: skills/security-waiver
+    ~/.agents/skills/tdd-guard:
+      path: skills/tdd-guard
+
+# ---------------------------------------------------------------------------
+# Claude Code — base files + redundanter Skills-Symlink ins Repo
 # ---------------------------------------------------------------------------
 - link:
     ~/.claude/CLAUDE.md:
@@ -35,69 +74,57 @@
       path: configs/claude/settings.json
     ~/.claude/hooks:
       path: configs/claude/hooks
+    ~/.claude/skills/ac-validate:
+      path: skills/ac-validate
+    ~/.claude/skills/ac-waiver:
+      path: skills/ac-waiver
     ~/.claude/skills/code-review-expert:
       path: skills/code-review-expert
+    ~/.claude/skills/design-review:
+      path: skills/design-review
     ~/.claude/skills/issue-pickup:
       path: skills/issue-pickup
+    ~/.claude/skills/nachfrage-respond:
+      path: skills/nachfrage-respond
     ~/.claude/skills/pr-open:
       path: skills/pr-open
+    ~/.claude/skills/release-checklist:
+      path: skills/release-checklist
     ~/.claude/skills/review-gate:
       path: skills/review-gate
+    ~/.claude/skills/security-audit:
+      path: skills/security-audit
+    ~/.claude/skills/security-waiver:
+      path: skills/security-waiver
+    ~/.claude/skills/tdd-guard:
+      path: skills/tdd-guard
 
 # ---------------------------------------------------------------------------
-# Cursor CLI
-# cli-config.json is tricky — existing install will likely have one.
-# backup-existing.sh moves a real file out of the way before we symlink.
+# Cursor CLI — rules + AGENTS.md. Skills-Bridge über MCP (Follow-up-Issue).
+# cli-config.json NICHT symlinken: cursor-agent mcp add mutiert sie.
 # ---------------------------------------------------------------------------
 - link:
     ~/.cursor/AGENTS.md:
       path: AGENTS.md
     ~/.cursor/rules/global.mdc:
       path: configs/cursor/rules/global.mdc
-    # ~/.cursor/cli-config.json NICHT symlinken: cursor-agent mcp add mutiert sie
-    # und ersetzt Symlinks durch reale Files. Copy-Template via shell-Step.
-    ~/.cursor/skills/code-review-expert:
-      path: skills/code-review-expert
-    ~/.cursor/skills/issue-pickup:
-      path: skills/issue-pickup
-    ~/.cursor/skills/pr-open:
-      path: skills/pr-open
-    ~/.cursor/skills/review-gate:
-      path: skills/review-gate
 
 # ---------------------------------------------------------------------------
-# Gemini CLI
+# Gemini CLI — AGENTS.md only. Skills kommen via ~/.agents/skills/.
+# settings.json NICHT symlinken: register.sh mutiert sie live (jq-merge).
 # ---------------------------------------------------------------------------
 - link:
     ~/.gemini/GEMINI.md:
       path: AGENTS.md
-    # ~/.gemini/settings.json NICHT symlinken: register.sh mutiert sie live (jq-merge).
-    # Copy-Template via shell-Step unten.
-    ~/.gemini/skills/code-review-expert:
-      path: skills/code-review-expert
-    ~/.gemini/skills/issue-pickup:
-      path: skills/issue-pickup
-    ~/.gemini/skills/pr-open:
-      path: skills/pr-open
-    ~/.gemini/skills/review-gate:
-      path: skills/review-gate
 
 # ---------------------------------------------------------------------------
-# Codex CLI
+# Codex CLI — AGENTS.md only. Skills kommen via ~/.agents/skills/ (offizieller
+# Codex-Discovery-Pfad, siehe developers.openai.com/codex/skills).
+# config.toml NICHT symlinken: register.sh mutiert sie live (toml-merge).
 # ---------------------------------------------------------------------------
 - link:
     ~/.codex/AGENTS.md:
       path: AGENTS.md
-    # ~/.codex/config.toml NICHT symlinken: register.sh mutiert sie live (toml-merge).
-    # Copy-Template via shell-Step unten.
-    ~/.codex/skills/code-review-expert:
-      path: skills/code-review-expert
-    ~/.codex/skills/issue-pickup:
-      path: skills/issue-pickup
-    ~/.codex/skills/pr-open:
-      path: skills/pr-open
-    ~/.codex/skills/review-gate:
-      path: skills/review-gate
 
 # ---------------------------------------------------------------------------
 # Copy-Templates für live-mutable Configs (NICHT symlinked).

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -46,31 +46,43 @@ printf '%sSymlink targets → agent-stack repo%s\n' "${C_DIM}" "${C_RESET}"
 # format: "link_path:expected_target_relative_to_repo"
 # NOTE: Nur statische Dateien sind symlinked. Live-mutable Configs (cursor/cli-config,
 # gemini/settings.json, codex/config.toml) sind lokale Kopien — separat geprüft.
+#
+# Skills-Pfad-Strategie (siehe install.conf.yaml):
+# - ~/.agents/skills/<name>     → Primär-SoT für Codex + Gemini (offizielle Discovery-Pfade)
+# - ~/.claude/skills/<name>     → redundanter Claude-spezifischer Pfad
+# - ~/.cursor/skills/           → nicht mehr angelegt (Cursor hat keinen nativen Support,
+#                                  MCP-Bridge als Follow-up — siehe #25)
+# - ~/.codex/skills/            → nicht mehr angelegt (Codex nutzt ~/.agents/skills/)
+SKILLS=(
+    ac-validate
+    ac-waiver
+    code-review-expert
+    design-review
+    issue-pickup
+    nachfrage-respond
+    pr-open
+    release-checklist
+    review-gate
+    security-audit
+    security-waiver
+    tdd-guard
+)
+
 SYMLINK_CHECKS=(
     "${HOME}/.claude/CLAUDE.md:AGENTS.md"
     "${HOME}/.claude/settings.json:configs/claude/settings.json"
     "${HOME}/.claude/hooks:configs/claude/hooks"
-    "${HOME}/.claude/skills/code-review-expert:skills/code-review-expert"
-    "${HOME}/.claude/skills/issue-pickup:skills/issue-pickup"
-    "${HOME}/.claude/skills/pr-open:skills/pr-open"
-    "${HOME}/.claude/skills/review-gate:skills/review-gate"
     "${HOME}/.cursor/AGENTS.md:AGENTS.md"
     "${HOME}/.cursor/rules/global.mdc:configs/cursor/rules/global.mdc"
-    "${HOME}/.cursor/skills/code-review-expert:skills/code-review-expert"
-    "${HOME}/.cursor/skills/issue-pickup:skills/issue-pickup"
-    "${HOME}/.cursor/skills/pr-open:skills/pr-open"
-    "${HOME}/.cursor/skills/review-gate:skills/review-gate"
     "${HOME}/.gemini/GEMINI.md:AGENTS.md"
-    "${HOME}/.gemini/skills/code-review-expert:skills/code-review-expert"
-    "${HOME}/.gemini/skills/issue-pickup:skills/issue-pickup"
-    "${HOME}/.gemini/skills/pr-open:skills/pr-open"
-    "${HOME}/.gemini/skills/review-gate:skills/review-gate"
     "${HOME}/.codex/AGENTS.md:AGENTS.md"
-    "${HOME}/.codex/skills/code-review-expert:skills/code-review-expert"
-    "${HOME}/.codex/skills/issue-pickup:skills/issue-pickup"
-    "${HOME}/.codex/skills/pr-open:skills/pr-open"
-    "${HOME}/.codex/skills/review-gate:skills/review-gate"
 )
+
+# Skill-Symlinks dynamisch aus der Liste generieren
+for skill in "${SKILLS[@]}"; do
+    SYMLINK_CHECKS+=("${HOME}/.agents/skills/${skill}:skills/${skill}")
+    SYMLINK_CHECKS+=("${HOME}/.claude/skills/${skill}:skills/${skill}")
+done
 
 # Live-mutable Configs: existieren als reale Datei (KEIN Symlink), werden von
 # register.sh in-place mutiert. Nur Existenz-Check.
@@ -190,21 +202,30 @@ fi
 # ---------------------------------------------------------------------------
 # 3. Skill-Directories erreichbar
 # ---------------------------------------------------------------------------
-printf '\n%sSkill directories reachable across CLIs%s\n' "${C_DIM}" "${C_RESET}"
+printf '\n%sSkill directories reachable (primary %s~/.agents/skills%s + Claude)%s\n' \
+    "${C_DIM}" "${C_RESET}" "${C_DIM}" "${C_RESET}"
 
-SKILLS=(code-review-expert issue-pickup pr-open review-gate)
-CLI_DIRS=(".claude" ".cursor" ".gemini" ".codex")
-
-for cli_dir in "${CLI_DIRS[@]}"; do
-    for skill in "${SKILLS[@]}"; do
-        path="${HOME}/${cli_dir}/skills/${skill}/SKILL.md"
+# Alle 12 Skills müssen in ~/.agents/skills/ (primary) UND ~/.claude/skills/ (redundant) da sein.
+# Cursor + Gemini + Codex erreichen sie über ~/.agents/skills/ (nativ) oder via eigenen Fallback.
+for skill in "${SKILLS[@]}"; do
+    for base in ".agents" ".claude"; do
+        path="${HOME}/${base}/skills/${skill}/SKILL.md"
         if [[ -r "${path}" ]]; then
-            _pass "${cli_dir}/skills/${skill}/SKILL.md"
+            _pass "${base}/skills/${skill}/SKILL.md"
         else
             _fail "missing: ${path}"
         fi
     done
 done
+
+# Cursor: dokumentierter Gap — keine nativen Skills, siehe Follow-up-Issue
+if [[ -d "${HOME}/.cursor/skills" ]]; then
+    _warn "\${HOME}/.cursor/skills existiert noch (legacy) — kann bei Bedarf entfernt werden"
+fi
+# Codex: nicht mehr an ${HOME}/.codex/skills/, sondern ${HOME}/.agents/skills/
+if [[ -d "${HOME}/.codex/skills" ]]; then
+    _warn "\${HOME}/.codex/skills existiert noch (legacy) — Codex nutzt \${HOME}/.agents/skills/"
+fi
 
 # ---------------------------------------------------------------------------
 # 4. ai-review-pipeline (optional Integration)


### PR DESCRIPTION
## Summary

- Primär-SoT für Skills ist jetzt \`~/.agents/skills/\` — nativ gelesen von Codex + Gemini.
- \`~/.claude/skills/\` bekommt redundante Symlinks (Claude-Pfad-Erwartung).
- Alle **12 Skills** sind jetzt cross-CLI verfügbar (vorher: 4).
- Broken \`~/.codex/skills/\` Symlinks entfernt (Codex liest dort nicht).
- Cursor-MCP-Bridge als Follow-up #25 separiert (nicht-trivial, eigener Python-Wrapper nötig).

Closes #22
Refs #20 (Epic), #25 (Cursor-Follow-up)

## Recherche-Befunde (2026-04-24)

| CLI | Skills-Pfad | Quelle |
|---|---|---|
| Codex | \`~/.agents/skills/\` | [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills) |
| Gemini | \`~/.agents/skills/\` oder \`~/.gemini/skills/\` | [geminicli.com/docs/cli/skills](https://geminicli.com/docs/cli/skills/) |
| Claude | \`~/.claude/skills/\` | anthropic.com |
| Cursor | kein nativer Support | [forum.cursor.com/t/146837](https://forum.cursor.com/t/is-skills-supported/146837) |

## Änderungen

| File | Change |
|---|---|
| \`install.conf.yaml\` | Primär-SoT \`~/.agents/skills/\` + Claude-Redundanz für alle 12 Skills |
| \`scripts/verify.sh\` | Prüft neue Pfad-Struktur, warnt bei Legacy-Dirs |
| \`AGENTS.md\` §14 + §17 | Skills-SoT-Pfad-Doku aktualisiert |

## Acceptance Criteria Verification

| AC | Test |
|---|---|
| Alle 12 Skills in \`~/.agents/skills\` | \`install.conf.yaml\` listet 12 Entries ✅ |
| Claude sieht Skills über redundanten Pfad | 12 Entries für \`~/.claude/skills/\` ✅ |
| \`verify.sh\` validiert neuen Pfad | Dynamische Generation aus SKILLS-Array ✅ |
| Cursor MCP-Bridge (Follow-up) | #25 geöffnet mit 3 Implementierungs-Optionen ✅ |
| Skills sind tool-neutral | \`grep\` zeigt alle 12 haben \`audience: [claude, cursor, gemini, codex]\` ✅ |

## Test plan

- [x] \`python3 -m pytest tests/\` → 36 passed
- [x] \`bash tests/test_mcp_servers.sh\` → PASS
- [x] \`python3 -c "import yaml; yaml.safe_load(open('install.conf.yaml'))"\` → valid
- [x] \`shellcheck scripts/verify.sh\` → clean
- [x] \`verify.sh\` ohne install.sh → erwartet red (neue Symlinks noch nicht angelegt)
- [ ] Nach Merge: \`./install.sh\` im Home → alle 12 Skills in beiden Pfaden verfügbar
- [ ] Nach Merge: \`verify.sh\` → 100% green für Skill-Sektionen
- [ ] Nach Merge in Cursor-Session: Hinweis dass Skills über Follow-up-Issue #25 kommen

## Bekannte Gaps

- Cursor-Skills werden erst nach Implementierung von #25 verfügbar (MCP-Bridge). Bis dahin haben Cursor-User keinen Skills-Zugriff — aber auch heute nicht, da \`~/.cursor/skills/\` ohnehin nie von Cursor gelesen wurde.
- Legacy-Verzeichnisse \`~/.cursor/skills/\` und \`~/.codex/skills/\` bleiben nach Merge bestehen (dotbot löscht nicht automatisch). \`verify.sh\` warnt darüber. Manuelles Cleanup optional: \`rm -rf ~/.cursor/skills ~/.codex/skills\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)