### PR TITLE
docs(wiki): post-cutover cleanup

### DIFF
--- a/docs/wiki/00-ueberblick.md
+++ b/docs/wiki/00-ueberblick.md
@@ -81,14 +81,15 @@ Jede Stage liefert einen Score 1–10 plus Findings. Die Consensus-Logik aggregi
 
 Details: [`10-konzepte/10-consensus-scoring.md`](10-konzepte/10-consensus-scoring.md).
 
-### Phasen-Modell
+### Phasen-Modell (Historie)
 
-Die Toolchain läuft aktuell in zwei Modi parallel auf dem Zielprojekt:
+Die Toolchain lief bis zum 2026-04-24 in zwei Modi parallel auf dem ai-portal-Repo. Mit dem **Phase-5-Cutover am 2026-04-24 (ai-portal PR#44)** ist **v2 die einzige Pipeline**:
 
-- **v1** (Legacy-Pipeline, live, blocking): Fest verdrahtet im ai-portal-Repo, Stages als einzelne YAML-Workflows. Required-Check `ai-review/consensus` blockiert Merges.
-- **v2 Shadow** (neue Pipeline, non-blocking): Nutzt die extrahierte `ai-review-pipeline` aus dem agent-stack-Ökosystem. Status-Context `ai-review-v2/consensus` — parallel, aber nicht in der Branch-Protection.
+- Die 5 v1-Legacy-Workflows (`ai-code-review.yml`, `ai-security-review.yml`, `ai-design-review.yml`, `ai-review-scope-check.yml`, `ai-review-consensus.yml`) wurden gelöscht.
+- `ai-review-v2-shadow.yml` → `ai-review.yml` (renamed), Shadow-Flags entfernt, `blocking: true` für alle 5 Stages.
+- Required-Check ist weiterhin `ai-review/consensus` — aber jetzt hinter der v2-Logik (kein Gap beim Cutover, da Name beibehalten).
 
-Der Cutover von v1 auf v2 (Phase 5) tauscht nur die Required-Checks aus und aktiviert `blocking: true` in der Config. Details: [`10-konzepte/20-shadow-vs-cutover.md`](10-konzepte/20-shadow-vs-cutover.md) und [`30-workflows/40-cutover-phase-4-zu-5.md`](30-workflows/40-cutover-phase-4-zu-5.md).
+Das Shadow-Muster bleibt als **wiederverwendbares Playbook** für künftige Pipeline-Migrationen dokumentiert: [`10-konzepte/20-shadow-vs-cutover.md`](10-konzepte/20-shadow-vs-cutover.md) und [`30-workflows/40-cutover-phase-4-zu-5.md`](30-workflows/40-cutover-phase-4-zu-5.md). Changelog-Eintrag: [`80-historie/00-changelog.md#2026-04-24-phase-5-cutover-im-ai-portal-pr44`](80-historie/00-changelog.md).
 
 ### Infrastruktur-Fakten
 
@@ -103,13 +104,11 @@ Der Cutover von v1 auf v2 (Phase 5) tauscht nur die Required-Checks aus und akti
 
 Details pro Komponente in [`20-komponenten/`](20-komponenten/).
 
-### Was ist gerade live?
+### Was ist gerade live? (Stand 2026-04-24, Post-Cutover)
 
-Stand dieses Dokuments:
-
-- **Infrastruktur:** n8n Up 2+ Tage, Funnel aktiv, Runner online, alle drei n8n-Workflows aktiv (dispatcher, callback, escalation)
-- **Pipeline:** v1 Legacy läuft blocking im ai-portal, v2 Shadow läuft non-blocking auf demselben PR parallel
-- **Letzter E2E-Proof:** Shadow-Run #24853468198 mit allen 6 Jobs + Consensus success
+- **Infrastruktur:** n8n Up, Funnel aktiv, Runner online, alle drei n8n-Workflows aktiv (dispatcher, callback, escalation)
+- **Pipeline:** v2 ist die **einzige** Pipeline im ai-portal (seit Phase-5-Cutover am 2026-04-24, PR#44). Alle 5 Stages `blocking: true`, Required-Check `ai-review/consensus` hinter v2-Logik.
+- **Letzter Shadow-E2E-Proof vor Cutover:** Run #24853468198 mit allen 6 Jobs + Consensus success (dokumentiert im Changelog)
 - **Tests:** 13/13 Callback-Unit-Tests + 25/25 E2E-Validation-Checks grün
 
 Aktueller Status immer via [`ops/n8n/tests/ai-review-e2e-validate.sh`](../../ops/n8n/tests/ai-review-e2e-validate.sh) prüfbar.

--- a/docs/wiki/10-konzepte/00-ai-review-pipeline.md
+++ b/docs/wiki/10-konzepte/00-ai-review-pipeline.md
@@ -92,10 +92,10 @@ Details: [`40-setup/20-ai-review-config-schema.md`](../40-setup/20-ai-review-con
 
 ### Status-Contexts
 
-Jede Stage schreibt einen GitHub-Commit-Status:
+Jede Stage schreibt einen GitHub-Commit-Status. Seit dem Phase-5-Cutover (2026-04-24) ist nur noch ein Namespace live:
 
-- v1 Legacy-Pipeline (ai-portal): `ai-review/code`, `ai-review/code-cursor`, `ai-review/security`, `ai-review/design`, `ai-review/ac-validation`
-- v2 Shadow-Pipeline: `ai-review-v2/code`, `ai-review-v2/code-cursor`, `ai-review-v2/security`, `ai-review-v2/design`, `ai-review-v2/ac-validation`
+- Produktiv (seit 2026-04-24): `ai-review/code`, `ai-review/code-cursor`, `ai-review/security`, `ai-review/design`, `ai-review/ac-validation`
+- Historisch (Phase 4 Shadow, 2026-04-20 bis 2026-04-24): `ai-review-v2/*` — nicht mehr in Verwendung, Präfix-Mechanik bleibt als Playbook für künftige Shadow-Migrationen dokumentiert
 
 Das Präfix wird via CLI-Flag `--status-context-prefix` gesteuert. Details: [`70-reference/20-status-contexts.md`](../70-reference/20-status-contexts.md).
 

--- a/docs/wiki/10-konzepte/20-shadow-vs-cutover.md
+++ b/docs/wiki/10-konzepte/20-shadow-vs-cutover.md
@@ -1,6 +1,8 @@
-# Shadow-Mode vs. Cutover — Warum zwei Pipelines parallel laufen
+# Shadow-Mode vs. Cutover — Historisches Deployment-Pattern + Playbook
 
-> **TL;DR:** Auf dem ai-portal-Repo laufen aktuell zwei unabhängige Review-Pipelines gleichzeitig. Die alte (v1) wurde vor der Extraction direkt im Repo entwickelt und ist seit langem eingespielt; sie blockiert Merges wenn Reviews fehlschlagen. Die neue (v2) nutzt die extrahierte Pipeline aus dem agent-stack-Ökosystem und läuft bewusst nicht-blockierend. Dieser Shadow-Modus erlaubt es, die neue Pipeline unter Real-Bedingungen zu validieren, ohne Entwicklungsarbeit zu riskieren. Der Cutover (Phase 5) tauscht v1 gegen v2 aus, sobald v2 bewiesen hat, dass sie zuverlässig das richtige Urteil liefert.
+> **Status seit 2026-04-24:** Phase-5-Cutover im ai-portal abgeschlossen — v2 ist die einzige Pipeline, v1 Legacy-Workflows sind gelöscht. Diese Seite beschreibt das Muster als **wiederverwendbares Playbook** für künftige Pipeline-Migrationen, nicht als aktuellen Laufzustand.
+>
+> **TL;DR (historisch):** Zwischen 2026-04-20 und 2026-04-24 liefen auf ai-portal zwei unabhängige Review-Pipelines gleichzeitig. Die alte (v1) war direkt im Repo verdrahtet und blockierte Merges. Die neue (v2) nutzte die extrahierte `ai-review-pipeline` aus dem agent-stack-Ökosystem und lief bewusst nicht-blockierend. Dieser Shadow-Modus erlaubte es, die neue Pipeline unter Real-Bedingungen zu validieren, ohne Entwicklungsarbeit zu riskieren. Der Cutover (Phase 5) tauschte v1 gegen v2 aus, nachdem v2 bewiesen hatte, dass sie zuverlässig das richtige Urteil liefert.
 
 ## Wie es funktioniert
 

--- a/docs/wiki/20-komponenten/20-ai-portal-integration.md
+++ b/docs/wiki/20-komponenten/20-ai-portal-integration.md
@@ -1,6 +1,8 @@
 # ai-portal Integration — Wie das Ziel-Projekt die Pipeline nutzt
 
-> **TL;DR:** Das ai-portal-Repo ist das erste Produktiv-Projekt, das die AI-Review-Toolchain nutzt. Es hat eine alte Pipeline, die seit langem eingespielt ist und Merges blockiert (v1), sowie eine neue Pipeline, die parallel nicht-blockierend mitläuft (v2 Shadow). Die Integration besteht aus einer Config-Datei, einem Shadow-Workflow und einer Branch-Protection-Einstellung. Sobald v2 sich über mehrere Wochen als zuverlässig erweist, wird v1 abgeschaltet.
+> **Status seit 2026-04-24:** Phase-5-Cutover abgeschlossen (PR#44). Die Seite beschreibt die Post-Cutover-Realität: **nur noch v2**, die 5 v1-Legacy-Workflows gelöscht, `ai-review-v2-shadow.yml` → `ai-review.yml` umbenannt, alle 5 Stages `blocking: true`. Phase-4-Mechanik (zwei parallele Pipelines) siehe [`10-konzepte/20-shadow-vs-cutover.md`](../10-konzepte/20-shadow-vs-cutover.md) als Playbook für künftige Migrationen.
+>
+> **TL;DR (Post-Cutover):** Das ai-portal-Repo ist das erste Produktiv-Projekt, das die AI-Review-Toolchain nutzt. Die Integration besteht aus einer Config-Datei (`.ai-review/config.yaml`), einem produktiven Workflow (`ai-review.yml`) und einer Branch-Protection-Einstellung (`ai-review/consensus` als Required-Check). Shadow-Phase war 2026-04-20 bis 2026-04-24.
 
 ## Wie es funktioniert
 

--- a/docs/wiki/30-workflows/00-neuer-pr-e2e.md
+++ b/docs/wiki/30-workflows/00-neuer-pr-e2e.md
@@ -100,7 +100,7 @@ Jeder Job schreibt **genau einen** Status pro PR-HEAD-SHA:
 | ac-validate | `ai-review/ac-validation` oder `ai-review-v2/ac-validation` | success / pending / failure |
 | consensus | `ai-review/consensus` oder `ai-review-v2/consensus` | success / pending / failure |
 
-Der **Context-Präfix** ist entscheidend: `ai-review/*` ist v1 Legacy (required), `ai-review-v2/*` ist v2 Shadow (non-required in Phase 4). Details: [`70-reference/20-status-contexts.md`](../70-reference/20-status-contexts.md).
+Der **Context-Präfix** ist entscheidend: Seit dem Phase-5-Cutover am 2026-04-24 ist `ai-review/*` der einzige produktive Namespace. Das `ai-review-v2/*`-Präfix aus der Shadow-Phase ist nicht mehr in Verwendung. Details: [`70-reference/20-status-contexts.md`](../70-reference/20-status-contexts.md).
 
 ### Die Consensus-Aggregation im Detail
 

--- a/docs/wiki/30-workflows/10-button-click-callback.md
+++ b/docs/wiki/30-workflows/10-button-click-callback.md
@@ -220,8 +220,9 @@ jobs:
           echo "Action: ${{ inputs.action }}"
           echo "PR: ${{ inputs.pr_number }}"
           echo "User: ${{ inputs.user_id }}"
-      # Phase 4: nur Log-Stub
-      # Phase 5 TODO: echte Aktion per action
+      # Stand 2026-04-24: Log-Stub bewusst aktiv — Button-Actions werden noch nicht
+      # automatisiert ausgeführt. Follow-up tracked in agent-stack-Issue #20 (Epic)
+      # unter "Phase 2 — Audit-Trail & Visibility" bzw. "Phase 5 — Hardening".
 ```
 
 In Phase 4 ist der Workflow ein **Stub** — er loggt nur, was geklickt wurde, ohne die Aktion auszuführen. Das reicht um den E2E-Flow zu validieren, ohne bei Bugs echte Merges/Retries auszulösen.

--- a/docs/wiki/30-workflows/40-cutover-phase-4-zu-5.md
+++ b/docs/wiki/30-workflows/40-cutover-phase-4-zu-5.md
@@ -1,5 +1,7 @@
-# Cutover Phase 4 → 5 — Shadow in Produktion überführen
+# Cutover Phase 4 → 5 — Shadow in Produktion überführen (Playbook)
 
+> **Status seit 2026-04-24:** Dieses Playbook wurde für den ai-portal-Cutover (PR#44) am 2026-04-24 einmal durchlaufen. Die Seite bleibt als **wiederverwendbare Anleitung** für künftige Pipeline-Migrationen (z.B. Schema-Registry, weitere Repos). Code-Beispiele zeigen noch die ai-portal-spezifischen Pfade — beim nächsten Einsatz entsprechend adaptieren.
+>
 > **TL;DR:** Der Wechsel von der parallel-laufenden Shadow-Pipeline zur produktiven Pipeline ist eine sorgfältig geordnete Sequenz von fünf Schritten. Zuerst muss die Shadow-Pipeline über mehrere Wochen beweisen, dass sie dieselben Urteile fällt wie die Legacy-Pipeline. Dann werden die Stages von `blocking: false` auf `blocking: true` umgeschaltet, der Discord-Kanal vom Shadow- auf den Produktiv-Kanal gewechselt, die Branch-Protection in GitHub umgestellt, und zuletzt die alte Pipeline abgeschaltet. Der Rollback ist bis Schritt 4 einfach — einfach die vorigen Konfigurationen wiederherstellen. Nach Schritt 5 (alte Pipeline gelöscht) wird's aufwändiger.
 
 ## Wie es funktioniert

--- a/docs/wiki/70-reference/20-status-contexts.md
+++ b/docs/wiki/70-reference/20-status-contexts.md
@@ -1,6 +1,8 @@
-# Status-Contexts — `ai-review/*` vs. `ai-review-v2/*`
+# Status-Contexts — `ai-review/*` (seit Cutover 2026-04-24 einziger Raum)
 
-> **TL;DR:** Jede Review-Stage schreibt am Ende einen GitHub-Commit-Status auf den PR-HEAD-Commit. Der "Context-Name" dieses Status entscheidet, ob die Branch-Protection ihn als Required-Check behandelt. Aktuell laufen zwei parallele Präfix-Räume: `ai-review/*` ist die Legacy-v1-Pipeline (required), `ai-review-v2/*` ist die neue Shadow-Pipeline (non-required). Diese Seite zeigt die vollständige Matrix und was beim Cutover zu Phase 5 mit den Namen passiert.
+> **Status seit 2026-04-24:** Seit dem Phase-5-Cutover (ai-portal PR#44) existiert nur noch der `ai-review/*`-Namespace. Der `ai-review-v2/*`-Präfix wurde beim Cutover aufgelöst. Die Matrix unten bleibt als **historisches Playbook** für künftige Shadow-Migrationen dokumentiert.
+>
+> **TL;DR (historisch):** Jede Review-Stage schreibt am Ende einen GitHub-Commit-Status auf den PR-HEAD-Commit. Der "Context-Name" dieses Status entscheidet, ob die Branch-Protection ihn als Required-Check behandelt. In Phase 4 liefen zwei parallele Präfix-Räume: `ai-review/*` (v1 Legacy, required) und `ai-review-v2/*` (v2 Shadow, non-required). Beim Cutover zu Phase 5 wurde v1 gelöscht, v2 übernahm den `ai-review/*`-Namespace.
 
 ## Kontext-Matrix
 

--- a/docs/wiki/70-reference/30-channel-mapping.md
+++ b/docs/wiki/70-reference/30-channel-mapping.md
@@ -1,6 +1,8 @@
 # Discord-Channel-Mapping
 
-> **TL;DR:** Jedes Projekt hat zwei Discord-Channels: einen regulären für Produktions-Reviews und einen Shadow-Channel für nicht-blockierende Tests. Dazu kommt ein gemeinsamer Alerts-Kanal für Eskalationen. Alle Channels leben in der Discord-Guild "Nathan Ops". Die Channel-IDs werden als Env-Variablen im Runner-Env referenziert, damit Scripts und Workflows sie nicht hart verdrahten müssen.
+> **Status seit 2026-04-24:** ai-portal nutzt nach dem Phase-5-Cutover nur noch den Produktions-Channel `#ai-review-ai-portal`. Der Shadow-Channel `#ai-review-shadow-ai-portal` ist stillgelegt (bleibt als Historie). Die Channel-Liste unten zeigt alle erstellten Kanäle — die `_SHADOW`-Slots sind nur relevant, wenn eine neue Repo-spezifische Shadow-Migration startet.
+>
+> **TL;DR:** Jedes Projekt hat in Phase 4 zwei Discord-Channels: einen regulären für Produktions-Reviews und einen Shadow-Channel für nicht-blockierende Tests. Dazu kommt ein gemeinsamer Alerts-Kanal für Eskalationen. Alle Channels leben in der Discord-Guild "Nathan Ops". Die Channel-IDs werden als Env-Variablen im Runner-Env referenziert, damit Scripts und Workflows sie nicht hart verdrahten müssen.
 
 ## Channel-Tabelle
 


### PR DESCRIPTION
## Summary

Nach dem Phase-5-Cutover am 2026-04-24 (ai-portal PR#44) zeigten 9 Wiki-Seiten noch den Phase-4-Shadow-Zustand als aktuell. Diese PR reframed die Seiten als **Post-Cutover-Realität + Historie/Playbook**:

- **Produktion (Post-Cutover)**: v2 ist die einzige Pipeline. Banner + aktualisierte TL;DRs zeigen das.
- **Historie/Playbook**: Der Phase-4-Mechanik-Body bleibt erhalten als wiederverwendbares Muster für künftige Shadow-Migrationen.

Closes #32
Refs #20 (Epic)

## Änderungen

| File | Change |
|---|---|
| `docs/wiki/00-ueberblick.md` | "Phasen-Modell" + "Was ist gerade live?" auf Post-Cutover |
| `docs/wiki/10-konzepte/00-ai-review-pipeline.md` | Status-Contexts markiert v2/* als historisch |
| `docs/wiki/10-konzepte/20-shadow-vs-cutover.md` | TL;DR als Historie/Playbook |
| `docs/wiki/20-komponenten/20-ai-portal-integration.md` | TL;DR auf Post-Cutover |
| `docs/wiki/30-workflows/00-neuer-pr-e2e.md` | Context-Präfix-Absatz |
| `docs/wiki/30-workflows/10-button-click-callback.md` | TODO-Marker ehrlich dokumentiert |
| `docs/wiki/30-workflows/40-cutover-phase-4-zu-5.md` | Als wiederverwendbares Playbook positioniert |
| `docs/wiki/70-reference/20-status-contexts.md` | Matrix-Titel + TL;DR |
| `docs/wiki/70-reference/30-channel-mapping.md` | Shadow-Slots als stillgelegt markiert |

## Acceptance Criteria Verification

| AC | Test |
|---|---|
| Überblick listet Post-Cutover-Status | 00-ueberblick.md "Phasen-Modell (Historie)" + "Was ist gerade live? (Stand 2026-04-24, Post-Cutover)" ✅ |
| Shadow-Konzept als Historie/Playbook | 20-shadow-vs-cutover.md Banner "Status seit 2026-04-24" ✅ |
| Button-Callback TODO-Marker ehrlich | 10-button-click-callback.md:223 "Stand 2026-04-24: Log-Stub bewusst aktiv … Follow-up tracked in Epic #20" ✅ |
| grep liefert nur Treffer in Historie-Bereichen | Alle verbleibenden "v1 Legacy"/"v2 Shadow"-Treffer stehen in Dateien mit Post-Cutover-Banner oder Mermaid-Diagrammen der Phase-4-Mechanik ✅ |

## Test plan

- [x] `grep -rn "v1 Legacy\|v2 Shadow\|Phase 5 TODO" docs/wiki/` — alle Treffer in Files mit Historie-Banner oder in 80-historie/*
- [x] `pytest tests/` → 36 passed (docs-only change)
- [ ] Nach Merge: Wiki-Renderer zeigt Banner prominent über dem Body

## Out-of-Scope (Folge-PRs)

- Komplette Neu-Schreibung der Body-Texte (hier nur Banner + TL;DR) → optional wenn künftige Verwirrung auftritt
- Phase 6 (Wiki-Modell-Refs aus MODEL_REGISTRY.env auto-generieren) → eigener PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)