### PR TITLE
feat(docs): wiki-overview auto-generiert aus MODEL_REGISTRY.env

### DIFF
--- a/docs/wiki/00-ueberblick.md
+++ b/docs/wiki/00-ueberblick.md
@@ -60,13 +60,19 @@ Die **Bewegungsrichtung** der Daten im Normalfall:
 
 ### Die fünf Review-Stufen
 
+<!-- wiki-review-stages-start -->
+<!-- AUTO-GENERIERT aus ai-review-pipeline/registry/MODEL_REGISTRY.env -->
+<!-- NICHT manuell editieren — Änderungen kommen aus dem Weekly-Drift-Check -->
+<!-- Regeneriert: 2026-04-24 -->
+
 | Stufe | KI-Modell | Blickwinkel | Tool-Integration |
 |---|---|---|---|
-| **Code-Review** | Codex (GPT-5) | Funktionale Korrektheit, TypeScript strict, TDD-Compliance | `ai-review stage code-review` |
+| **Code-Review** | Codex (`gpt-5.5`) | Funktionale Korrektheit, TypeScript strict, TDD-Compliance | `ai-review stage code-review` |
 | **Code-Cursor** | Cursor (composer-2) | Zweite Meinung mit anderem Modell | `ai-review stage cursor-review` |
-| **Security** | Gemini 2.5 Pro + `semgrep` | OWASP, Secret-Leaks, Injection-Risiken | `ai-review stage security` |
-| **Design** | Claude Opus 4.7 | UI/UX, Accessibility, Design-System-Konformität | `ai-review stage design` |
+| **Security** | Gemini (`gemini-3.1-pro-preview`) + `semgrep` | OWASP, Secret-Leaks, Injection-Risiken | `ai-review stage security` |
+| **Design** | Claude (`claude-opus-4-7`) | UI/UX, Accessibility, Design-System-Konformität | `ai-review stage design` |
 | **AC-Validation** | Codex primary + Claude second-opinion | 1:1-Mapping Acceptance-Criteria ↔ Test | `ai-review ac-validate` |
+<!-- wiki-review-stages-end -->
 
 Details: [`10-konzepte/00-ai-review-pipeline.md`](10-konzepte/00-ai-review-pipeline.md).
 

--- a/scripts/generate-model-docs.py
+++ b/scripts/generate-model-docs.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
-"""Generiert die Modell-Sektionen in AGENTS.md aus der committed Registry.
+"""Generiert die Modell-Sektionen in AGENTS.md + Wiki-Overview aus der committed Registry.
 
-Ziel: CLAUDE.md §8 (Reviewer-Modell-Defaults) und §11 (LLM-Modelle) werden
+Ziel: AGENTS.md §8 (Reviewer-Modell-Defaults) + §11 (LLM-Modelle) UND die
+"Die fünf Review-Stufen"-Tabelle in docs/wiki/00-ueberblick.md werden
 NICHT manuell gepflegt — sondern aus ai-review-pipeline/registry/MODEL_REGISTRY.env
 via Template-Replacement generiert. Das eliminiert Doc-Drift.
 
 Mechanik:
-- Sektionen sind zwischen `<!-- model-registry-start -->` und
-  `<!-- model-registry-end -->` markiert
-- Skript liest Registry, baut Markdown-Block, ersetzt alles dazwischen
+- AGENTS.md-Sektion: zwischen `<!-- model-registry-start -->` / `<!-- model-registry-end -->`
+- Wiki-Tabelle:      zwischen `<!-- wiki-review-stages-start -->` / `<!-- wiki-review-stages-end -->`
+- Skript liest Registry, baut jeweils Markdown-Block, ersetzt alles dazwischen
 - Pre-commit-Hook verhindert manuelle Edits zwischen den Markern
 
 Usage:
-  python3 scripts/generate-model-docs.py [--check] [--agents-md PATH]
+  python3 scripts/generate-model-docs.py [--check] [--agents-md PATH] [--wiki-overview PATH]
 
-  --check      Dry-Run, Exit 1 bei Drift (für pre-commit)
-  --agents-md  Alternative AGENTS.md (für Tests)
+  --check          Dry-Run, Exit 1 bei Drift (für pre-commit)
+  --agents-md      Alternative AGENTS.md (für Tests)
+  --wiki-overview  Alternative Wiki-Overview-Datei (für Tests)
 """
 
 from __future__ import annotations
@@ -31,13 +33,22 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_AGENTS_MD = REPO_ROOT / "AGENTS.md"
+DEFAULT_WIKI_OVERVIEW = REPO_ROOT / "docs" / "wiki" / "00-ueberblick.md"
 DEFAULT_REGISTRY = (
-    Path.home() / "projects" / "ai-review-pipeline" /
-    "src" / "ai_review_pipeline" / "registry" / "MODEL_REGISTRY.env"
+    Path.home()
+    / "projects"
+    / "ai-review-pipeline"
+    / "src"
+    / "ai_review_pipeline"
+    / "registry"
+    / "MODEL_REGISTRY.env"
 )
 
 SECTION_START = "<!-- model-registry-start -->"
 SECTION_END = "<!-- model-registry-end -->"
+
+WIKI_SECTION_START = "<!-- wiki-review-stages-start -->"
+WIKI_SECTION_END = "<!-- wiki-review-stages-end -->"
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +66,7 @@ def parse_registry(path: Path) -> dict[str, str]:
         if not stripped or stripped.startswith("#") or "=" not in stripped:
             continue
         key, _, value = stripped.partition("=")
-        result[key.strip()] = value.strip().strip('"\'')
+        result[key.strip()] = value.strip().strip("\"'")
     return result
 
 
@@ -67,6 +78,7 @@ def parse_registry(path: Path) -> dict[str, str]:
 def render_registry_section(registry: dict[str, str]) -> str:
     """Baut Markdown-Block für AGENTS.md (zwischen den start/end-Markern)."""
     today = datetime.now(timezone.utc).date().isoformat()
+
     # Safe-get: fehlende Keys werden als "(nicht gepinnt)" gerendert
     def _g(key: str) -> str:
         return registry.get(key) or "(nicht gepinnt)"
@@ -104,33 +116,104 @@ Manuelle Overrides via `AI_REVIEW_MODEL_<ROLE>` Env-Var oder
 {SECTION_END}"""
 
 
+def render_wiki_review_stages(registry: dict[str, str]) -> str:
+    """Baut die "Die fünf Review-Stufen"-Tabelle für docs/wiki/00-ueberblick.md."""
+    today = datetime.now(timezone.utc).date().isoformat()
+
+    def _g(key: str) -> str:
+        return registry.get(key) or "(nicht gepinnt)"
+
+    return f"""{WIKI_SECTION_START}
+<!-- AUTO-GENERIERT aus ai-review-pipeline/registry/MODEL_REGISTRY.env -->
+<!-- NICHT manuell editieren — Änderungen kommen aus dem Weekly-Drift-Check -->
+<!-- Regeneriert: {today} -->
+
+| Stufe | KI-Modell | Blickwinkel | Tool-Integration |
+|---|---|---|---|
+| **Code-Review** | Codex (`{_g("OPENAI_MAIN")}`) | Funktionale Korrektheit, TypeScript strict, TDD-Compliance | `ai-review stage code-review` |
+| **Code-Cursor** | Cursor (composer-2) | Zweite Meinung mit anderem Modell | `ai-review stage cursor-review` |
+| **Security** | Gemini (`{_g("GEMINI_PRO")}`) + `semgrep` | OWASP, Secret-Leaks, Injection-Risiken | `ai-review stage security` |
+| **Design** | Claude (`{_g("CLAUDE_OPUS")}`) | UI/UX, Accessibility, Design-System-Konformität | `ai-review stage design` |
+| **AC-Validation** | Codex primary + Claude second-opinion | 1:1-Mapping Acceptance-Criteria ↔ Test | `ai-review ac-validate` |
+{WIKI_SECTION_END}"""
+
+
 # ---------------------------------------------------------------------------
-# AGENTS.md editing
+# File editing
 # ---------------------------------------------------------------------------
 
 
-def replace_section(content: str, new_section: str) -> str:
-    """Ersetzt den Bereich zwischen den Markers. Wirft bei fehlenden Markers."""
-    start_idx = content.find(SECTION_START)
-    end_idx = content.find(SECTION_END)
+def _replace_between(
+    content: str, new_section: str, start_marker: str, end_marker: str, file_label: str
+) -> str:
+    """Ersetzt den Bereich zwischen spezifischen Markers. Wirft bei fehlenden Markers."""
+    start_idx = content.find(start_marker)
+    end_idx = content.find(end_marker)
     if start_idx == -1 or end_idx == -1:
         raise ValueError(
-            f"AGENTS.md enthält die Marker '{SECTION_START}' / '{SECTION_END}' nicht. "
+            f"{file_label} enthält die Marker '{start_marker}' / '{end_marker}' nicht. "
             f"Erster Setup: Füge die beiden Marker einmalig an der Stelle ein, wo "
             f"die Registry-Sektion leben soll."
         )
     if end_idx < start_idx:
         raise ValueError(
-            "AGENTS.md: end-Marker steht vor start-Marker. Datei ist korrupt."
+            f"{file_label}: end-Marker steht vor start-Marker. Datei ist korrupt."
         )
 
-    end_idx += len(SECTION_END)
+    end_idx += len(end_marker)
     return content[:start_idx] + new_section + content[end_idx:]
+
+
+def replace_section(content: str, new_section: str) -> str:
+    """Backward-kompatibler Wrapper: ersetzt den AGENTS.md-Block."""
+    return _replace_between(
+        content, new_section, SECTION_START, SECTION_END, "AGENTS.md"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
+
+def _process_target(
+    *,
+    path: Path,
+    render: callable,
+    start_marker: str,
+    end_marker: str,
+    label: str,
+    check_only: bool,
+) -> tuple[int, bool]:
+    """Verarbeitet ein Target-File. Return (exit_code, changed).
+
+    exit_code: 0 ok, 1 drift im check-mode, 2 file-kaputt
+    changed:   ob die Datei (potentiell) geschrieben wurde
+    """
+    if not path.is_file():
+        print(f"❌ {label} nicht gefunden: {path}", file=sys.stderr)
+        return 2, False
+
+    before = path.read_text()
+    new_section = render
+    try:
+        after = _replace_between(before, new_section, start_marker, end_marker, label)
+    except ValueError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2, False
+
+    if before == after:
+        print(f"✅ {label} ist auf dem aktuellen Stand ({path}).")
+        return 0, False
+
+    if check_only:
+        print(f"⚠️  {label} weicht von der Registry ab ({path}).", file=sys.stderr)
+        print("   Führe aus: python3 scripts/generate-model-docs.py", file=sys.stderr)
+        return 1, False
+
+    path.write_text(after)
+    print(f"📝 {label} regeneriert: {path}")
+    return 0, True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -140,6 +223,12 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=DEFAULT_AGENTS_MD,
         help="Pfad zur AGENTS.md (default: agent-stack/AGENTS.md)",
+    )
+    parser.add_argument(
+        "--wiki-overview",
+        type=Path,
+        default=DEFAULT_WIKI_OVERVIEW,
+        help="Pfad zur Wiki-Overview (default: agent-stack/docs/wiki/00-ueberblick.md)",
     )
     parser.add_argument(
         "--registry",
@@ -157,28 +246,36 @@ def main(argv: list[str] | None = None) -> int:
     if not args.registry.is_file():
         print(f"❌ Registry nicht gefunden: {args.registry}", file=sys.stderr)
         return 2
-    if not args.agents_md.is_file():
-        print(f"❌ AGENTS.md nicht gefunden: {args.agents_md}", file=sys.stderr)
-        return 2
 
     registry = parse_registry(args.registry)
-    new_section = render_registry_section(registry)
 
-    before = args.agents_md.read_text()
-    after = replace_section(before, new_section)
+    worst_exit = 0
+    # AGENTS.md
+    rc, _ = _process_target(
+        path=args.agents_md,
+        render=render_registry_section(registry),
+        start_marker=SECTION_START,
+        end_marker=SECTION_END,
+        label="AGENTS.md",
+        check_only=args.check,
+    )
+    worst_exit = max(worst_exit, rc)
 
-    if before == after:
-        print("✅ AGENTS.md ist auf dem aktuellen Stand.")
-        return 0
+    # Wiki-Overview — skip wenn file nicht existiert (für Projekte ohne Wiki)
+    if args.wiki_overview.is_file():
+        rc, _ = _process_target(
+            path=args.wiki_overview,
+            render=render_wiki_review_stages(registry),
+            start_marker=WIKI_SECTION_START,
+            end_marker=WIKI_SECTION_END,
+            label="Wiki-Overview",
+            check_only=args.check,
+        )
+        worst_exit = max(worst_exit, rc)
+    else:
+        print(f"ℹ️  Wiki-Overview nicht gefunden — skip ({args.wiki_overview})")
 
-    if args.check:
-        print("⚠️  AGENTS.md weicht von der Registry ab.", file=sys.stderr)
-        print("   Führe aus: python3 scripts/generate-model-docs.py", file=sys.stderr)
-        return 1
-
-    args.agents_md.write_text(after)
-    print(f"📝 AGENTS.md regeneriert: {args.agents_md}")
-    return 0
+    return worst_exit
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_model_docs.py
+++ b/tests/test_generate_model_docs.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 # Filename mit Hyphens → spec-loader
-_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "generate-model-docs.py"
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "generate-model-docs.py"
+)
 _SPEC = importlib.util.spec_from_file_location("generate_model_docs", _SCRIPT_PATH)
 assert _SPEC and _SPEC.loader
 gen_docs = importlib.util.module_from_spec(_SPEC)
@@ -68,6 +70,31 @@ Nach-Text
         self.assertIn("Marker", str(ctx.exception))
 
 
+class WikiRenderTests(unittest.TestCase):
+    """Tests für die zweite Render-Funktion (Wiki-Overview)."""
+
+    def test_wiki_section_has_registry_values(self) -> None:
+        registry = {
+            "OPENAI_MAIN": "gpt-5.5",
+            "GEMINI_PRO": "gemini-3.1-pro-preview",
+            "CLAUDE_OPUS": "claude-opus-4-7",
+        }
+        output = gen_docs.render_wiki_review_stages(registry)
+        self.assertIn("gpt-5.5", output)
+        self.assertIn("gemini-3.1-pro-preview", output)
+        self.assertIn("claude-opus-4-7", output)
+
+    def test_wiki_section_starts_and_ends_with_wiki_markers(self) -> None:
+        output = gen_docs.render_wiki_review_stages({"GEMINI_PRO": "x"})
+        self.assertTrue(output.startswith(gen_docs.WIKI_SECTION_START))
+        self.assertTrue(output.endswith(gen_docs.WIKI_SECTION_END))
+
+    def test_wiki_section_has_distinct_markers_from_agents_section(self) -> None:
+        """Sanity: AGENTS- und Wiki-Marker sind unterschiedlich."""
+        self.assertNotEqual(gen_docs.SECTION_START, gen_docs.WIKI_SECTION_START)
+        self.assertNotEqual(gen_docs.SECTION_END, gen_docs.WIKI_SECTION_END)
+
+
 class EndToEndTests(unittest.TestCase):
     """Simuliert den ganzen Flow: Registry → AGENTS.md-Update."""
 
@@ -91,10 +118,14 @@ class EndToEndTests(unittest.TestCase):
                 f"# Header\n\n{gen_docs.SECTION_START}\nold content\n{gen_docs.SECTION_END}\n\nFooter\n"
             )
 
-            exit_code = gen_docs.main([
-                "--agents-md", str(agents_md),
-                "--registry", str(registry_path),
-            ])
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--registry",
+                    str(registry_path),
+                ]
+            )
             self.assertEqual(exit_code, 0)
 
             after = agents_md.read_text()
@@ -118,11 +149,15 @@ class EndToEndTests(unittest.TestCase):
                 f"{gen_docs.SECTION_START}\nstale\n{gen_docs.SECTION_END}\n"
             )
 
-            exit_code = gen_docs.main([
-                "--agents-md", str(agents_md),
-                "--registry", str(registry_path),
-                "--check",
-            ])
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--registry",
+                    str(registry_path),
+                    "--check",
+                ]
+            )
             self.assertEqual(exit_code, 1)
             # Im Check-Mode darf die Datei NICHT geschrieben werden
             self.assertIn("stale", agents_md.read_text())
@@ -142,11 +177,116 @@ class EndToEndTests(unittest.TestCase):
             section = gen_docs.render_registry_section(registry)
             agents_md.write_text(f"Header\n\n{section}\n\nFooter\n")
 
-            exit_code = gen_docs.main([
-                "--agents-md", str(agents_md),
-                "--registry", str(registry_path),
-                "--check",
-            ])
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--wiki-overview",
+                    str(tmp_path / "no-such-wiki.md"),
+                    "--registry",
+                    str(registry_path),
+                    "--check",
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+
+    def test_wiki_full_update_cycle(self) -> None:
+        """Beide Targets werden in einem Lauf regeneriert."""
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            registry_path = tmp_path / "r.env"
+            registry_path.write_text(
+                "CLAUDE_OPUS=claude-opus-4-7\nCLAUDE_SONNET=s\nCLAUDE_HAIKU=h\n"
+                "GEMINI_PRO=gemini-3.1-pro-preview\nGEMINI_FLASH=gf\n"
+                "OPENAI_MAIN=gpt-5.5\n"
+                "CODEX_CLI_VERSION=c\nCURSOR_AGENT_CLI_VERSION=cc\n"
+            )
+            agents_md = tmp_path / "AGENTS.md"
+            agents_md.write_text(
+                f"# A\n\n{gen_docs.SECTION_START}\nstale\n{gen_docs.SECTION_END}\n"
+            )
+            wiki = tmp_path / "00-ueberblick.md"
+            wiki.write_text(
+                f"# W\n\n{gen_docs.WIKI_SECTION_START}\nold\n{gen_docs.WIKI_SECTION_END}\n"
+            )
+
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--wiki-overview",
+                    str(wiki),
+                    "--registry",
+                    str(registry_path),
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+
+            self.assertIn("gemini-3.1-pro-preview", agents_md.read_text())
+            wiki_after = wiki.read_text()
+            self.assertIn("gpt-5.5", wiki_after)
+            self.assertIn("gemini-3.1-pro-preview", wiki_after)
+            self.assertIn("claude-opus-4-7", wiki_after)
+
+    def test_wiki_check_mode_detects_drift(self) -> None:
+        """--check erkennt Wiki-Drift und meldet Exit 1 auch wenn AGENTS in-sync ist."""
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            registry_path = tmp_path / "r.env"
+            registry_path.write_text(
+                "CLAUDE_OPUS=claude-opus-4-7\nCLAUDE_SONNET=s\nCLAUDE_HAIKU=h\n"
+                "GEMINI_PRO=gemini-3.1-pro-preview\nGEMINI_FLASH=gf\n"
+                "OPENAI_MAIN=gpt-5.5\n"
+                "CODEX_CLI_VERSION=c\nCURSOR_AGENT_CLI_VERSION=cc\n"
+            )
+            registry = gen_docs.parse_registry(registry_path)
+            agents_md = tmp_path / "AGENTS.md"
+            agents_md.write_text(gen_docs.render_registry_section(registry))
+
+            wiki = tmp_path / "00-ueberblick.md"
+            wiki.write_text(
+                f"{gen_docs.WIKI_SECTION_START}\nstale\n{gen_docs.WIKI_SECTION_END}\n"
+            )
+
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--wiki-overview",
+                    str(wiki),
+                    "--registry",
+                    str(registry_path),
+                    "--check",
+                ]
+            )
+            self.assertEqual(exit_code, 1)
+            self.assertIn("stale", wiki.read_text())
+
+    def test_wiki_missing_is_skip_not_error(self) -> None:
+        """--wiki-overview auf nicht-existente Datei → Skip, kein Fehler."""
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            registry_path = tmp_path / "r.env"
+            registry_path.write_text(
+                "CLAUDE_OPUS=x\nCLAUDE_SONNET=s\nCLAUDE_HAIKU=h\n"
+                "GEMINI_PRO=g\nGEMINI_FLASH=gf\nOPENAI_MAIN=oc\n"
+                "CODEX_CLI_VERSION=c\nCURSOR_AGENT_CLI_VERSION=cc\n"
+            )
+            agents_md = tmp_path / "AGENTS.md"
+            registry = gen_docs.parse_registry(registry_path)
+            agents_md.write_text(gen_docs.render_registry_section(registry))
+
+            missing_wiki = tmp_path / "gibts-nicht.md"
+            exit_code = gen_docs.main(
+                [
+                    "--agents-md",
+                    str(agents_md),
+                    "--wiki-overview",
+                    str(missing_wiki),
+                    "--registry",
+                    str(registry_path),
+                ]
+            )
             self.assertEqual(exit_code, 0)
 
 


### PR DESCRIPTION
## Summary

- `scripts/generate-model-docs.py` erhält ein zweites Target: die "Die fünf Review-Stufen"-Tabelle in `docs/wiki/00-ueberblick.md` wird jetzt genauso aus der Registry regeneriert wie die Blöcke in AGENTS.md
- Neue Marker `<!-- wiki-review-stages-start -->` / `<!-- wiki-review-stages-end -->` umrahmen die Tabelle
- 6 neue Tests für das Wiki-Target (WikiRenderTests + End-to-End), 42/42 pytest grün

Closes #34
Refs #20 (Epic)

## Motivation

Wiki-Overview nannte Modell-Versionen hart verdrahtet (`Gemini 2.5 Pro`, `Codex (GPT-5)`, `Claude Opus 4.7`). Seit PR #12 ist `MODEL_REGISTRY.env` Single-Source-of-Truth — aber der Mechanismus existierte nur für AGENTS.md. Jedes Modell-Upgrade hätte sofort wieder Drift in der Wiki-Overview erzeugt. Dieser PR schließt die Lücke.

## Änderungen

| File | Change |
|---|---|
| `scripts/generate-model-docs.py` | `--wiki-overview` Flag, `WIKI_SECTION_START/END` Marker, `render_wiki_review_stages()` Render-Fn, `_process_target`-Helper für Multi-Target-Verarbeitung |
| `docs/wiki/00-ueberblick.md` | Marker um die Review-Stufen-Tabelle gesetzt, konkrete Modell-Pins jetzt aus Registry (gpt-5.5, gemini-3.1-pro-preview, claude-opus-4-7) |
| `tests/test_generate_model_docs.py` | 6 neue Tests (WikiRenderTests + End-to-End Wiki-Zyklen) |

## Acceptance Criteria Verification

| AC | Test |
|---|---|
| Script regeneriert Wiki-Tabelle aus Registry | `test_wiki_full_update_cycle` prüft, dass gpt-5.5/gemini/claude-opus in Output landen ✅ |
| Idempotenz | `python3 scripts/generate-model-docs.py --check` auf frisch regeneriertem Repo → Exit 0 ✅ |
| --check erkennt Wiki-Drift | `test_wiki_check_mode_detects_drift` ✅ |
| Fehlendes Wiki ist Skip | `test_wiki_missing_is_skip_not_error` ✅ |

## Test plan

- [x] `python3 -m pytest tests/` → 42 passed
- [x] `python3 scripts/generate-model-docs.py` → AGENTS.md in-sync, Wiki-Overview regeneriert
- [x] `python3 scripts/generate-model-docs.py --check` nach Re-Gen → Exit 0 (idempotent)
- [x] Drift-Sim: `sed -i 's/gpt-5.5/OLD/' docs/wiki/00-ueberblick.md && python3 scripts/generate-model-docs.py --check` → Exit 1 mit klarer Fehlermeldung
- [ ] Nach Merge: nächster Registry-Drift-Check in [`.github/workflows/model-registry-drift-check.yml`](../.github/workflows/model-registry-drift-check.yml) regeneriert auch die Wiki-Tabelle automatisch

## Hinweis zur Reihenfolge

Dieser PR baut auf `main` auf, nicht auf PR #33 (Post-Cutover-Cleanup). Beide PRs ändern `docs/wiki/00-ueberblick.md` — Merge-Conflict erwartbar. Empfohlene Merge-Reihenfolge:

1. **PR #31** (BASELINE-Drift-Guard) — unabhängig
2. **PR #33** (Post-Cutover-Cleanup) — framed v1/v2-Dualität als Historie
3. **Dieser PR (#35)** — ersetzt die hart verdrahtete Review-Stufen-Tabelle durch Marker/Auto-Gen

Bei Conflict in `00-ueberblick.md`: PR #33 ändert Phase-Modell + Live-Status-Block; dieser PR ändert nur die Tabelle. Beide Bereiche sind räumlich getrennt, Conflict sollte linear lösbar sein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)