### PR TITLE
docs(readme): stale plan-pointer → wiki + changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ agent-stack/
 
 ## Weiterführend
 
-- Plan für die Implementierung: Phasen 1–5 in
-  `~/.claude/plans/reports-projects-ai-portal-docs-v2-40-a-iridescent-flask.md`
-- `ai-review-pipeline` — eigenes Repo (pip-Package + `gh ai-review`
-  Extension), ab Phase 3
+- [`docs/wiki/`](docs/wiki/) — vollständiges Wiki (Konzepte, Komponenten,
+  Workflows, Setup-Runbooks, Reference). Einstieg:
+  [`docs/wiki/00-ueberblick.md`](docs/wiki/00-ueberblick.md).
+- [`docs/wiki/80-historie/00-changelog.md`](docs/wiki/80-historie/00-changelog.md) —
+  Chronologie der Entwicklung inkl. Phase-5-Cutover (2026-04-24).
+- [`ai-review-pipeline`](https://github.com/EtroxTaran/ai-review-pipeline) —
+  eigenes Repo (pip-Package + `gh ai-review` Extension), produktiv seit
+  Phase-5-Cutover.
 - OpenClaw Workspace — Nathan-Identität + Sub-Workspaces (parallel,
-  referenziert von AGENTS.md)
+  referenziert von AGENTS.md §1).
 
 ## Lizenz
 


### PR DESCRIPTION
## Summary

- README.md:79 Plan-Pointer auf lokale \`~/.claude/plans/reports-projects-ai-portal-docs-v2-40-a-iridescent-flask.md\` entfernt (Datei nie committed + nach Phase-5-Cutover obsolet)
- "Weiterführend"-Sektion zeigt jetzt auf committete Quellen: Wiki + Changelog + ai-review-pipeline Repo

Closes #36
Refs #20 (Epic)

## Änderungen

\`README.md\` — "Weiterführend"-Sektion: toter lokaler Pfad raus, Wiki/Changelog/ai-review-pipeline-Links rein.

## Acceptance Criteria Verification

| AC | Test |
|---|---|
| README enthält keinen toten lokalen Plan-Pfad | \`grep "reports-projects-ai-portal-docs-v2" README.md\` → leer ✅ |
| "Weiterführend" verweist auf committete Quellen | Sektion linkt docs/wiki/, docs/wiki/80-historie/00-changelog.md, ai-review-pipeline Repo ✅ |

## Test plan

- [x] \`grep "reports-projects-ai-portal-docs-v2\\|iridescent-flask" README.md\` → leer
- [x] Alle Links sind klickbar und zeigen auf committete Quellen
- [ ] Nach Merge: GitHub-Web-Preview des README rendert die neuen Links korrekt

## Nicht im Scope

- voiceEnabled-Dokumentation: bereits in PR #31 (BASELINE-Drift-Guard) in \`configs/BASELINE.md\` erledigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)